### PR TITLE
jlamillan/support oel 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,14 +164,14 @@ worker_ssh_ingress = "0.0.0.0/0"
 $ terraform output ssh_private_key > generated/instances_id_rsa
 # Retrieve public IP for etcd nodes
 $ terraform output etcd_public_ips
-# Log in as user ubuntu to the Canonical Ubuntu OS
-$ ssh -i `pwd`/generated/instances_id_rsa ubuntu@ETCD_INSTANCE_IP
+# Log in as user opc to the OEL OS
+$ ssh -i `pwd`/generated/instances_id_rsa oel@ETCD_INSTANCE_IP
 # Retrieve public IP for k8s masters
 $ terraform output master_public_ips
-$ ssh -i `pwd`/generated/instances_id_rsa ubuntu@K8SMASTER_INSTANCE_IP
+$ ssh -i `pwd`/generated/instances_id_rsa oel@K8SMASTER_INSTANCE_IP
 # Retrieve public IP for k8s workers
 $ terraform output worker_public_ips
-$ ssh -i `pwd`/generated/instances_id_rsa ubuntu@K8SWORKER_INSTANCE_IP
+$ ssh -i `pwd`/generated/instances_id_rsa oel@K8SWORKER_INSTANCE_IP
 ```
 
 ### Mandatory Input Variables:
@@ -238,7 +238,7 @@ flannel_ver                         | v0.7.1             | Version of Flannel to
 k8s_ver                             | 1.7.4              | Version of K8s to install (master and workers)
 k8s_dns_ver                         | 1.14.2             | Version of Kube DNS to install
 k8s_dashboard_ver                   | 1.6.3              | Version of Kubernetes dashboard to install
-instance_os_ver                     | 16.04              | Version of Ubuntu operating system
+instance_os_ver                     | 7.4                | Version of OEL operating system
 
 #### Other
 name                                | default                 | description
@@ -353,7 +353,7 @@ See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Installed on OCI Instances
 
-* Canonical Ubuntu (14.04)
+* Oracle Linux Enterprise (7.4)
 * etcd - (default v3.2.2)
 * flannel - (default v0.7.1)
 * docker - (default 17.03.0-ce)

--- a/README.md
+++ b/README.md
@@ -165,13 +165,13 @@ $ terraform output ssh_private_key > generated/instances_id_rsa
 # Retrieve public IP for etcd nodes
 $ terraform output etcd_public_ips
 # Log in as user opc to the OEL OS
-$ ssh -i `pwd`/generated/instances_id_rsa oel@ETCD_INSTANCE_IP
+$ ssh -i `pwd`/generated/instances_id_rsa opc@ETCD_INSTANCE_IP
 # Retrieve public IP for k8s masters
 $ terraform output master_public_ips
-$ ssh -i `pwd`/generated/instances_id_rsa oel@K8SMASTER_INSTANCE_IP
+$ ssh -i `pwd`/generated/instances_id_rsa opc@K8SMASTER_INSTANCE_IP
 # Retrieve public IP for k8s workers
 $ terraform output worker_public_ips
-$ ssh -i `pwd`/generated/instances_id_rsa oel@K8SWORKER_INSTANCE_IP
+$ ssh -i `pwd`/generated/instances_id_rsa opc@K8SWORKER_INSTANCE_IP
 ```
 
 ### Mandatory Input Variables:
@@ -232,7 +232,7 @@ worker_nodeport_ingress             | 10.0.0.0/16 (VCN only)  | A CIDR notation 
 #### Software Versions Installed on OCI Instances
 name                                | default            | description
 ------------------------------------|--------------------|------------
-docker_ver                          | 17.03              | Version of Docker to install
+docker_ver                          | 17.03.1            | Version of Docker to install
 etcd_ver                            | v3.2.2             | Version of etcd to install
 flannel_ver                         | v0.7.1             | Version of Flannel to install
 k8s_ver                             | 1.7.4              | Version of K8s to install (master and workers)
@@ -356,7 +356,7 @@ See [CONTRIBUTING](CONTRIBUTING.md) for details.
 * Oracle Linux Enterprise (7.4)
 * etcd - (default v3.2.2)
 * flannel - (default v0.7.1)
-* docker - (default 17.03.0-ce)
+* docker - (default 17.03.1.ce)
 * apt-transport-https - (default 1.2.20)
 * kubernetes - (default v1.7.4)
   * master(s) (`kube-apiserver`, `kube-controller-manager`, `kube-scheduler`, `kubernetes-cni`, `kubectl`)

--- a/instances/etcd/cloud_init/bootstrap.template.sh
+++ b/instances/etcd/cloud_init/bootstrap.template.sh
@@ -26,7 +26,7 @@ iptables -F
 ###################
 # etcd
 
-# Get IP Adress of self
+# Get IP Address of self
 IP_LOCAL=$(ip route show to 0.0.0.0/0 | awk '{ print $5 }' | xargs ip addr show | grep -Po 'inet \K[\d.]+')
 SUBNET=$(getent hosts $IP_LOCAL | awk '{print $2}' | cut -d. -f2)
 
@@ -45,11 +45,11 @@ docker run -d \
 	-listen-peer-urls http://0.0.0.0:2380 \
 	-discovery ${etcd_discovery_url}
 
-# download etcdctl client  etcd_ver
+# Download etcdctl client etcd_ver
 curl -L --retry 3 https://github.com/coreos/etcd/releases/download/${etcd_ver}/etcd-${etcd_ver}-linux-amd64.tar.gz -o /tmp/etcd-${etcd_ver}-linux-amd64.tar.gz
 tar zxf /tmp/etcd-${etcd_ver}-linux-amd64.tar.gz -C /tmp/ && cp /tmp/etcd-${etcd_ver}-linux-amd64/etcd* /usr/local/bin/
 
-# Generate a flannel configuration that we will store into etcd using curl.
+# Generate a flannel configuration JSON that we will store into etcd using curl.
 cat >/tmp/flannel-network.json <<EOF
 {
   "Network": "${flannel_network_cidr}",

--- a/instances/etcd/datasources.tf
+++ b/instances/etcd/datasources.tf
@@ -1,7 +1,7 @@
-# Cloud call to get the OCID of the OS image to use
+# Gets the OCID of the OS image to use
 data "oci_core_images" "ImageOCID" {
   compartment_id           = "${var.compartment_ocid}"
-  operating_system         = "Canonical Ubuntu"
+  operating_system         = "Oracle Linux"
   operating_system_version = "${var.instance_os_ver}"
 }
 

--- a/instances/etcd/main.tf
+++ b/instances/etcd/main.tf
@@ -12,10 +12,11 @@ resource "oci_core_instance" "TFInstanceEtcd" {
   shape               = "${var.shape}"
   subnet_id           = "${var.subnet_id}"
 
-  metadata {
+  extended_metadata {
     roles               = "etcd"
     ssh_authorized_keys = "${var.ssh_public_key_openssh}"
     user_data           = "${base64encode(data.template_file.etcd-bootstrap.rendered)}"
+    tags = "group:etcd"
   }
 
   timeouts {

--- a/instances/etcd/variables.tf
+++ b/instances/etcd/variables.tf
@@ -10,17 +10,16 @@ variable "shape" {
 variable "subnet_id" {}
 variable "ssh_public_key_openssh" {}
 variable "domain_name" {}
-
 variable "label_prefix" {
   default = ""
 }
 
 variable "docker_ver" {
-  default = "docker-ce_17.03.0~ce-0~ubuntu-xenial_amd64"
+  default = "17.03.1.ce"
 }
 
 variable "instance_os_ver" {
-  default = "16.04"
+  default = "7.4"
 }
 
 variable "etcd_ver" {

--- a/instances/k8smaster/cloud_init/bootstrap.template.yaml
+++ b/instances/k8smaster/cloud_init/bootstrap.template.yaml
@@ -1,13 +1,17 @@
 #cloud-config
 
+bootcmd:
+  # Turn off SELinux
+  - setenforce 0
+
 write_files:
 # setup script
-  - path: "/tmp/setup.preflight.sh"
+  - path: "/root/setup.preflight.sh"
     permissions: "0777"
     encoding: b64
     content: |
       ${setup_preflight_sh_content}
-  - path: "/tmp/setup.sh"
+  - path: "/root/setup.sh"
     permissions: "0777"
     encoding: b64
     content: |
@@ -23,7 +27,7 @@ write_files:
     encoding: b64
     content: |
       ${kube_controller_manager_template_content}
-  - path: "/etc/kubernetes/manifests/kube-dns.yaml"
+  - path: "/root/services/kube-dns.yaml"
     permissions: "0755"
     encoding: b64
     content: |
@@ -38,38 +42,39 @@ write_files:
     encoding: b64
     content: |
       ${kube_scheduler_template_content}
-  - path: "/etc/kubernetes/manifests/kubernetes-dashboard.yaml"
+  - path: "/root/services/kubernetes-dashboard.yaml"
     permissions: "0755"
     encoding: b64
     content: |
       ${kube_dashboard_template_content}
+  - path: "/root/services/docker.service"
   - path: "/etc/kubernetes/manifests/kube-rbac-role-binding.yaml"
     permissions: "0755"
     encoding: b64
     content: |
       ${kube_rbac_content}
-  - path: "/home/ubuntu/services/docker.service"
+  - path: "/root/services/docker.service"
     permissions: "0600"
     encoding: b64
     content: |
       ${docker_service_content}
-  - path: "/home/ubuntu/services/flannel.service"
+  - path: "/root/services/flannel.service"
     permissions: "0600"
     encoding: b64
     content: |
       ${flannel_service_content}
-  - path: "/home/ubuntu/services/cni-bridge.service"
+  - path: "/root/services/cni-bridge.service"
     permissions: "0600"
     encoding: b64
     content: |
       ${cnibridge_service_content}
-  - path: "/home/ubuntu/services/cni-bridge.sh"
+  - path: "/root/services/cni-bridge.sh"
     permissions: "0600"
     encoding: b64
     content: |
       ${cnibridge_sh_content}
 # systemd services
-  - path: "/home/ubuntu/services/kubelet.service"
+  - path: "/root/services/kubelet.service"
     permissions: "0600"
     encoding: b64
     content: |
@@ -99,5 +104,5 @@ write_files:
 
 runcmd:
  - echo "Running k8s init..."
- - /tmp/setup.preflight.sh
+ - /root/setup.preflight.sh
  - echo "Finished k8s init."

--- a/instances/k8smaster/datasources.tf
+++ b/instances/k8smaster/datasources.tf
@@ -1,7 +1,7 @@
 # Gets the OCID of the OS image to use
 data "oci_core_images" "ImageOCID" {
   compartment_id           = "${var.compartment_ocid}"
-  operating_system         = "Canonical Ubuntu"
+  operating_system         = "Oracle Linux"
   operating_system_version = "${var.instance_os_ver}"
 }
 

--- a/instances/k8smaster/main.tf
+++ b/instances/k8smaster/main.tf
@@ -12,11 +12,13 @@ resource "oci_core_instance" "TFInstanceK8sMaster" {
   shape               = "${var.shape}"
   subnet_id           = "${var.subnet_id}"
 
-  metadata {
+  extended_metadata {
     roles               = "masters"
     ssh_authorized_keys = "${var.ssh_public_key_openssh}"
     user_data           = "${data.template_cloudinit_config.master.rendered}"
+    tags = "group:k8s-master"
   }
+
 
   timeouts {
     create = "60m"

--- a/instances/k8smaster/scripts/docker.service
+++ b/instances/k8smaster/scripts/docker.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network.target docker.socket firewalld.service cni-bridge.service
-Requires=docker.socket cni-bridge.service
+After=network.target firewalld.service cni-bridge.service
+Requires=cni-bridge.service
 
 [Service]
 Type=notify
@@ -17,7 +17,6 @@ ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 LimitNPROC=infinity
 LimitCORE=infinity
-TasksMax=infinity
 TimeoutStartSec=0
 Delegate=yes
 KillMode=process

--- a/instances/k8smaster/scripts/setup.preflight.sh
+++ b/instances/k8smaster/scripts/setup.preflight.sh
@@ -4,4 +4,4 @@ EXTERNAL_IP=$(curl -s -m 10 http://whatismyip.akamai.com/)
 
 mkdir -p /etc/kubernetes/auth /etc/kubernetes/manifests/
 
-bash -x /tmp/setup.sh | tee -a /root/setup.log
+bash -x /root/setup.sh | tee -a /root/setup.log

--- a/instances/k8smaster/scripts/setup.template.sh
+++ b/instances/k8smaster/scripts/setup.template.sh
@@ -4,19 +4,12 @@ EXTERNAL_IP=$(curl -s -m 10 http://whatismyip.akamai.com/)
 NAMESPACE=$(echo -n "${domain_name}" | sed "s/\.oraclevcn\.com//g")
 FQDN_HOSTNAME=$(getent hosts $(ip route get 1 | awk '{print $NF;exit}') | awk '{print $2}')
 
-# make sure ubuntu owns home dir
-chown ubuntu:ubuntu /home/ubuntu
-
-## create policy file that blocks autostart of services on install
-printf '#!/bin/sh\necho "All runlevel operations denied by policy" >&2\nexit 101\n' >/tmp/policy-rc.d && chmod +x /tmp/policy-rc.d
 ETCD_LB=${etcd_lb}
 export HOSTNAME=$(hostname)
 
 export IP_LOCAL=$(ip route show to 0.0.0.0/0 | awk '{ print $5 }' | xargs ip addr show | grep -Po 'inet \K[\d.]+')
 
 SUBNET=$(getent hosts $IP_LOCAL | awk '{print $2}' | cut -d. -f2)
-
-until apt-get update; do sleep 1 && echo -n "."; done
 
 ## download etcdctl client
 ######################################
@@ -35,7 +28,7 @@ curl -L --retry 3 https://github.com/coreos/flannel/releases/download/${flannel_
 	&& chmod 755 /usr/local/bin/flanneld
 export ETCD_SERVER=${etcd_lb}
 echo "IP_LOCAL: $IP_LOCAL ETCD_SERVER: $ETCD_SERVER"
-envsubst </home/ubuntu/services/flannel.service >/etc/systemd/system/flannel.service
+envsubst </root/services/flannel.service >/etc/systemd/system/flannel.service
 systemctl daemon-reload && systemctl enable flannel && systemctl start flannel
 
 ## INSTALL CNI PLUGIN
@@ -44,24 +37,34 @@ mkdir -p /opt/cni/bin /etc/cni/net.d
 curl -L --retry 3 https://github.com/containernetworking/cni/releases/download/v0.5.2/cni-amd64-v0.5.2.tgz -o /tmp/cni-plugin.tar.gz
 tar zxf /tmp/cni-plugin.tar.gz -C /opt/cni/bin/
 printf '{\n    "name": "podnet",\n    "type": "flannel",\n    "delegate": {\n        "isDefaultGateway": true\n    }\n}\n' >/etc/cni/net.d/10-flannel.conf
-cp /home/ubuntu/services/cni-bridge.service /etc/systemd/system/cni-bridge.service
-cp /home/ubuntu/services/cni-bridge.sh /usr/local/bin/cni-bridge.sh && chmod +x /usr/local/bin/cni-bridge.sh
+
+cp /root/services/cni-bridge.service /etc/systemd/system/cni-bridge.service
+cp /root/services/cni-bridge.sh /usr/local/bin/cni-bridge.sh && chmod +x /usr/local/bin/cni-bridge.sh
 systemctl enable cni-bridge && systemctl start cni-bridge
 
 # Install Docker prereqs
-apt-get install -y aufs-tools cgroupfs-mount libltdl7
+until yum -y install aufs-tools cgroupfs-mount libltdl7 unzip; do sleep 1 && echo -n "."; done
 
-# Download Docker
-curl -L --retry 3 https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/${docker_ver}.deb -o /tmp/${docker_ver}.deb
+# Stage master certs
+unzip /tmp/k8s-certs.zip -d /etc/kubernetes/ssl/
 
-# Disable debian autostart of service
-cp /tmp/policy-rc.d /usr/sbin/policy-rc.d
+# enable ol7 addons
+yum-config-manager --disable ol7_UEKR3
+yum-config-manager --enable ol7_addons ol7_latest ol7_UEKR4 ol7_optional ol7_optional_latest
 
 # Install Docker
-until dpkg -i /tmp/${docker_ver}.deb; do sleep 1 && echo -n "."; done
-systemctl stop docker.service
-rm -f /lib/systemd/system/docker.service && cat /home/ubuntu/services/docker.service >/lib/systemd/system/docker.service
-systemctl daemon-reload && systemctl restart docker
+until yum -y install docker-engine-${docker_ver}; do sleep 1 && echo -n "."; done
+
+systemctl stop docker
+
+# Disable irqbalance for performance
+service irqbalance stop
+yum -y erase irqbalance
+
+rm -f /lib/systemd/system/docker.service && cat /root/services/docker.service >/lib/systemd/system/docker.service
+systemctl enable docker
+systemctl daemon-reload
+systemctl restart docker
 
 # re-enable autostart
 rm -f /usr/sbin/policy-rc.d
@@ -78,14 +81,26 @@ echo "FQDN_HOSTNAME=$FQDN_HOSTNAME" >>/etc/environment_params
 # Drop firewall rules
 iptables -F
 
-# Update packages
-apt-get install -y apt-transport-https
-curl -s --retry 3 https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-echo 'deb http://apt.kubernetes.io/ kubernetes-xenial main' >/etc/apt/sources.list.d/kubernetes.list
-apt-get update
+cat <<EOF > /etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOF
 
-# install kubelet
-apt-get install -y kubelet=${k8s_ver}-00 kubectl
+# Disable SELinux and firewall
+setenforce 0
+systemctl stop firewalld.service
+systemctl disable firewalld.service
+
+## Install kubelet, kubectl, and kubernetes-cni
+###############################################
+yum-config-manager --add-repo http://yum.kubernetes.io/repos/kubernetes-el7-x86_64
+until yum install -y kubelet-${k8s_ver}-0 kubectl-${k8s_ver}-0; do sleep 1 && echo -n ".";done
 
 # Pull etcd docker image from registry
 docker pull quay.io/coreos/etcd:${etcd_ver}
@@ -93,7 +108,7 @@ docker pull quay.io/coreos/etcd:${etcd_ver}
 # Start etcd proxy container
 docker run -d \
 	-p 2380:2380 -p 2379:2379 \
-	-v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt \
+	-v /etc/ssl/certs/ca-bundle.crt:/etc/ssl/certs/ca-bundle.crt \
 	--net=host \
 	--restart=always \
 	quay.io/coreos/etcd:${etcd_ver} \
@@ -105,8 +120,9 @@ docker run -d \
 systemctl stop kubelet
 rm /lib/systemd/system/kubelet.service
 systemctl daemon-reload
-sed -e "s/__FQDN_HOSTNAME__/$FQDN_HOSTNAME/g" /home/ubuntu/services/kubelet.service >/etc/systemd/system/kubelet.service
+sed -e "s/__FQDN_HOSTNAME__/$FQDN_HOSTNAME/g" /root/services/kubelet.service >/etc/systemd/system/kubelet.service
 systemctl daemon-reload
+systemctl enable kubelet
 systemctl start kubelet
 
 until kubectl get all; do sleep 1 && echo -n "."; done
@@ -116,9 +132,10 @@ until [ "$(curl localhost:8080/healthz 2>/dev/null)" == "ok" ]; do
 	sleep 3
 done
 
-kubectl create -f /etc/kubernetes/manifests/kube-dns.yaml
+## install kube-dns
+kubectl create -f /root/services/kube-dns.yaml
 
 ## install kubernetes-dashboard
-kubectl create -f /etc/kubernetes/manifests/kubernetes-dashboard.yaml
+kubectl create -f /root/services/kubernetes-dashboard.yaml
 
 echo "Finished running setup.sh"

--- a/instances/k8smaster/variables.tf
+++ b/instances/k8smaster/variables.tf
@@ -22,11 +22,11 @@ variable "label_prefix" {
 variable "ssh_public_key_openssh" {}
 
 variable "docker_ver" {
-  default = "docker-ce_17.03.0~ce-0~ubuntu-xenial_amd64"
+  default = "17.03.1.ce"
 }
 
 variable "instance_os_ver" {
-  default = "16.04"
+  default = "7.4"
 }
 
 variable "etcd_ver" {

--- a/instances/k8sworker/cloud_init/bootstrap.template.yaml
+++ b/instances/k8sworker/cloud_init/bootstrap.template.yaml
@@ -1,13 +1,17 @@
 #cloud-config
 
+bootcmd:
+  # Turn off SELinux
+  - setenforce 0
+
 write_files:
 # setup script
-  - path: "/tmp/setup.preflight.sh"
+  - path: "/root/setup.preflight.sh"
     permissions: "0777"
     encoding: b64
     content: |
       ${setup_preflight_sh_content}
-  - path: "/tmp/setup.sh"
+  - path: "/root/setup.sh"
     permissions: "0777"
     encoding: b64
     content: |
@@ -25,31 +29,31 @@ write_files:
       ${worker_kubeconfig_template_content}
 
 # systemd services
-  - path: "/home/ubuntu/services/docker.service"
+  - path: "/root/services/docker.service"
     permissions: "0600"
     encoding: b64
     content: |
       ${docker_service_content}
 
-  - path: "/home/ubuntu/services/flannel.service"
+  - path: "/root/services/flannel.service"
     permissions: "0600"
     encoding: b64
     content: |
       ${flannel_service_content}
 
-  - path: "/home/ubuntu/services/cni-bridge.service"
+  - path: "/root/services/cni-bridge.service"
     permissions: "0600"
     encoding: b64
     content: |
       ${cnibridge_service_content}
 
-  - path: "/home/ubuntu/services/cni-bridge.sh"
+  - path: "/root/services/cni-bridge.sh"
     permissions: "0600"
     encoding: b64
     content: |
       ${cnibridge_sh_content}
 
-  - path: "/home/ubuntu/services/kubelet.service"
+  - path: "/root/services/kubelet.service"
     permissions: "0600"
     encoding: b64
     content: |
@@ -80,5 +84,5 @@ write_files:
 
 runcmd:
  - echo "Running k8s init..."
- - /tmp/setup.preflight.sh
+ - /root/setup.preflight.sh
  - echo "Finished k8s init."

--- a/instances/k8sworker/datasources.tf
+++ b/instances/k8sworker/datasources.tf
@@ -1,7 +1,7 @@
 # Gets the OCID of the OS image to use
 data "oci_core_images" "ImageOCID" {
   compartment_id           = "${var.compartment_ocid}"
-  operating_system         = "Canonical Ubuntu"
+  operating_system         = "Oracle Linux"
   operating_system_version = "${var.instance_os_ver}"
 }
 

--- a/instances/k8sworker/main.tf
+++ b/instances/k8sworker/main.tf
@@ -12,10 +12,11 @@ resource "oci_core_instance" "TFInstanceK8sWorker" {
   shape               = "${var.shape}"
   subnet_id           = "${var.subnet_id}"
 
-  metadata {
+  extended_metadata {
     roles               = "nodes"
     ssh_authorized_keys = "${var.ssh_public_key_openssh}"
     user_data           = "${data.template_cloudinit_config.master.rendered}"
+    tags = "group:k8s-worker"
   }
 
   provisioner "remote-exec" {
@@ -32,7 +33,7 @@ resource "oci_core_instance" "TFInstanceK8sWorker" {
 
     connection {
       host        = "${self.public_ip}"
-      user        = "ubuntu"
+      user        = "opc"
       private_key = "${var.ssh_private_key}"
       agent       = false
       timeout     = "30s"

--- a/instances/k8sworker/main.tf
+++ b/instances/k8sworker/main.tf
@@ -23,7 +23,7 @@ resource "oci_core_instance" "TFInstanceK8sWorker" {
     when = "destroy"
 
     inline = [
-      "nodeName=`getent hosts $(ip route get 1 | awk '{print $NF;exit}') | awk '{print $2}'`",
+      "nodeName=`getent hosts $(/usr/sbin/ip route get 1 | awk '{print $NF;exit}') | awk '{print $2}'`",
       "[ -e /usr/bin/kubectl ] && sudo kubectl --kubeconfig /etc/kubernetes/manifests/worker-kubeconfig.yaml drain $nodeName --force",
       "[ -e /usr/bin/kubectl ] && sudo kubectl --kubeconfig /etc/kubernetes/manifests/worker-kubeconfig.yaml delete node $nodeName",
       "exit 0",

--- a/instances/k8sworker/scripts/docker.service
+++ b/instances/k8sworker/scripts/docker.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network.target docker.socket firewalld.service cni-bridge.service
-Requires=docker.socket cni-bridge.service
+After=network.target firewalld.service cni-bridge.service
+Requires=cni-bridge.service
 
 [Service]
 Type=notify
@@ -16,7 +16,6 @@ ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 LimitNPROC=infinity
 LimitCORE=infinity
-TasksMax=infinity
 TimeoutStartSec=0
 Delegate=yes
 KillMode=process

--- a/instances/k8sworker/scripts/setup.preflight.sh
+++ b/instances/k8sworker/scripts/setup.preflight.sh
@@ -6,4 +6,4 @@ mkdir -p /etc/kubernetes/manifests /etc/kubernetes/auth
 
 # add tools
 curl --retry 3 http://stedolan.github.io/jq/download/linux64/jq -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq
-bash -x /tmp/setup.sh | tee -a /root/setup.log
+bash -x /root/setup.sh | tee -a /root/setup.log

--- a/instances/k8sworker/scripts/setup.template.sh
+++ b/instances/k8sworker/scripts/setup.template.sh
@@ -4,10 +4,10 @@ EXTERNAL_IP=$(curl -s -m 10 http://whatismyip.akamai.com/)
 NAMESPACE=$(echo -n "${domain_name}" | sed "s/\.oraclevcn\.com//g")
 FQDN_HOSTNAME=$(getent hosts $(ip route get 1 | awk '{print $NF;exit}') | awk '{print $2}')
 
-# pull instance metadata
+# Pull instance metadata
 curl -sL --retry 3 http://169.254.169.254/opc/v1/instance/ | tee /tmp/instance_meta.json
 
-## create policy file that blocks autostart of services on install
+## Create policy file that blocks autostart of services on install
 printf '#!/bin/sh\necho "All runlevel operations denied by policy" >&2\nexit 101\n' >/tmp/policy-rc.d && chmod +x /tmp/policy-rc.d
 export K8S_API_SERVER_LB=${master_lb}
 export ETCD_LB=${etcd_lb}
@@ -19,14 +19,16 @@ export IP_LOCAL=$(ip route show to 0.0.0.0/0 | awk '{ print $5 }' | xargs ip add
 SUBNET=$(getent hosts $IP_LOCAL | awk '{print $2}' | cut -d. -f2)
 export WORKER_IP=$IP_LOCAL
 
-## download etcdctl client
+## etcd
 ######################################
+
+# Download etcdctl client
 curl -L --retry 3 https://github.com/coreos/etcd/releases/download/${etcd_ver}/etcd-${etcd_ver}-linux-amd64.tar.gz -o /tmp/etcd-${etcd_ver}-linux-amd64.tar.gz
 tar zxf /tmp/etcd-${etcd_ver}-linux-amd64.tar.gz -C /tmp/ && cp /tmp/etcd-${etcd_ver}-linux-amd64/etcd* /usr/local/bin/
 
-# wait for etcd to become active (through the LB)
+# Wait for etcd to become active (through the LB)
 until [ $(/usr/local/bin/etcdctl --endpoints ${etcd_lb} cluster-health | grep '^cluster ' | grep -c 'is healthy$') == "1" ]; do
-	echo "Waiting for cluster to be healthy"
+	echo "Waiting for etcd cluster to be healthy"
 	sleep 1
 done
 
@@ -39,47 +41,21 @@ echo "IP_LOCAL: $IP_LOCAL ETCD_SERVER: $ETCD_SERVER"
 envsubst </root/services/flannel.service >/etc/systemd/system/flannel.service
 systemctl daemon-reload && systemctl enable flannel && systemctl start flannel
 
-## INSTALL CNI PLUGIN
+## Create cni bridge interface w/ IP from flannel
 ######################################
-mkdir -p /opt/cni/bin /etc/cni/net.d
-curl -L --retry 3 https://github.com/containernetworking/cni/releases/download/v0.5.2/cni-amd64-v0.5.2.tgz -o /tmp/cni-plugin.tar.gz
-tar zxf /tmp/cni-plugin.tar.gz -C /opt/cni/bin/
-printf '{\n    "name": "podnet",\n    "type": "flannel",\n    "delegate": {\n        "isDefaultGateway": true\n    }\n}\n' >/etc/cni/net.d/10-flannel.conf
 cp /root/services/cni-bridge.service /etc/systemd/system/cni-bridge.service
 cp /root/services/cni-bridge.sh /usr/local/bin/cni-bridge.sh && chmod +x /usr/local/bin/cni-bridge.sh
 systemctl enable cni-bridge && systemctl start cni-bridge
 
-###################################### DOCKER ######################################
-
-## Install Docker prereqs
+## Docker
 ######################################
-until yum -y install aufs-tools cgroupfs-mount libltdl7 unzip; do sleep && echo -n "."; done
-
-# Stage worker certs
-unzip /tmp/k8s-certs.zip -d /etc/kubernetes/ssl/
-
-# enable ol7 addons
-yum-config-manager --disable ol7_UEKR3
-yum-config-manager --enable ol7_addons ol7_latest ol7_UEKR4 ol7_optional ol7_optional_latest
-
-# Install Docker
 until yum -y install docker-engine-${docker_ver}; do sleep 1 && echo -n "."; done
-systemctl stop docker
 
-# Disable irqbalance for performance
-service irqbalance stop
-yum -y erase irqbalance
-
+# Configure Docker to use flannel
 rm -f /lib/systemd/system/docker.service && cat /root/services/docker.service >/lib/systemd/system/docker.service
-systemctl enable docker
 systemctl daemon-reload
-systemctl restart docker
-
-
-## Add default DNS
-######################################
-echo "nameserver 169.254.169.254" >>/etc/resolvconf/resolv.conf.d/base
-resolvconf -u
+systemctl enable docker
+systemctl start docker
 
 ## Output /etc/environment_params
 ######################################
@@ -91,7 +67,6 @@ echo "FQDN_HOSTNAME=$FQDN_HOSTNAME" >>/etc/environment_params
 ## Drop firewall rules
 ######################################
 iptables -F
-
 
 cat <<EOF > /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
@@ -109,17 +84,22 @@ setenforce 0
 systemctl stop firewalld.service
 systemctl disable firewalld.service
 
+# Configure pod network:
+mkdir -p /etc/cni/net.d
+cat >/etc/cni/net.d/10-flannel.conf <<EOF
+{
+	"name": "podnet",
+	"type": "flannel",
+	"delegate": {
+		"isDefaultGateway": true
+	}
+}
+EOF
+
 ## Install kubelet, kubectl, and kubernetes-cni
 ###############################################
 yum-config-manager --add-repo http://yum.kubernetes.io/repos/kubernetes-el7-x86_64
-until yum install -y kubelet-${k8s_ver}-0 kubectl-${k8s_ver}-0; do sleep 1 && echo -n ".";done
-
-until systemctl stop kubelet; do sleep 1; done
-mkdir -p /opt/cni/bin /etc/cni/net.d
-tar zxf /tmp/cni-plugin.tar.gz -C /opt/cni/bin/
-printf '{\n    "name": "podnet",\n    "type": "flannel",\n    "delegate": {\n        "isDefaultGateway": true\n    }\n}\n' >/etc/cni/net.d/10-flannel.conf
-
-###################################### ETCD ######################################
+until yum install -y kubelet-${k8s_ver}-0 kubectl-${k8s_ver}-0 kubernetes-cni; do sleep 1 && echo -n ".";done
 
 ## Pull etcd docker image from registry
 docker pull quay.io/coreos/etcd:${etcd_ver}
@@ -140,9 +120,8 @@ docker run -d \
 sed -e "s/__FQDN_HOSTNAME__/$FQDN_HOSTNAME/g" /etc/kubernetes/manifests/kube-proxy.yaml >/tmp/kube-proxy.yaml
 cat /tmp/kube-proxy.yaml >/etc/kubernetes/manifests/kube-proxy.yaml
 
-## Kubelet for the worker
+## kubelet for the worker
 ######################################
-rm /lib/systemd/system/kubelet.service
 systemctl daemon-reload
 
 AVAILABILITY_DOMAIN=$(jq -r '.availabilityDomain' /tmp/instance_meta.json | sed 's/:/-/g')
@@ -160,7 +139,7 @@ sed -e "s/__FQDN_HOSTNAME__/$FQDN_HOSTNAME/g" \
     -e "s/__NODE_SHAPE__/$NODE_SHAPE/g" \
     /root/services/kubelet.service > /etc/systemd/system/kubelet.service
 
-## wait for k8smaster to be available. possible race on pod networks otherwise
+## Wait for k8s master to be available. There is a possible race on pod networks otherwise.
 until [ "$(curl -k --cert /etc/kubernetes/ssl/apiserver.pem --key /etc/kubernetes/ssl/apiserver-key.pem $K8S_API_SERVER_LB/healthz 2>/dev/null)" == "ok" ]; do
 	sleep 3
 done

--- a/instances/k8sworker/variables.tf
+++ b/instances/k8sworker/variables.tf
@@ -25,11 +25,11 @@ variable "ssh_public_key_openssh" {}
 variable "ssh_private_key" {}
 
 variable "docker_ver" {
-  default = "docker-ce_17.03.0~ce-0~ubuntu-xenial_amd64"
+  default = "17.03.1.ce"
 }
 
 variable "instance_os_ver" {
-  default = "16.04"
+  default = "7.4"
 }
 
 variable "etcd_lb" {}
@@ -38,6 +38,7 @@ variable "etcd_ver" {
   default = "v3.2.2"
 }
 
+# TODO - because the bootstrap template uses yum, we only support OEL7
 variable "flannel_ver" {
   default = "v0.7.1"
 }

--- a/k8s-oci.tf
+++ b/k8s-oci.tf
@@ -409,7 +409,7 @@ module "instances-k8sworker-ad3" {
   etcd_ver                   = "${var.etcd_ver}"
   flannel_ver                = "${var.flannel_ver}"
   hostname_label_prefix      = "k8s-worker-ad3"
-  instance_os_ver            = "${var.instance_os_ver}"
+  instance_os_ver           = "${var.instance_os_ver}"
   k8s_ver                    = "${var.k8s_ver}"
   label_prefix               = "${var.label_prefix}"
   master_lb                  = "https://${module.k8smaster-public-lb.ip_addresses[0]}:443"

--- a/variables.tf
+++ b/variables.tf
@@ -186,7 +186,7 @@ variable "api_server_admin_token" {
 }
 
 variable "docker_ver" {
-  default = "docker-ce_17.03.0~ce-0~ubuntu-xenial_amd64"
+  default = "17.03.1.ce"
 }
 
 variable "etcd_ver" {
@@ -210,5 +210,5 @@ variable "k8s_dns_ver" {
 }
 
 variable "instance_os_ver" {
-  default = "16.04"
+  default = "7.4"
 }


### PR DESCRIPTION
This change _converts_ the shell scripts from supporting Ubuntu to OEL 7 that Joe did. I cleaned up some rough edges, updated OEL to 7.4, and did some testing.

Longer term, the goal is to move away from shell scripts to some configuration management tool, which will hopefully make it easier for us to support multiple OS's (without adding an egregious amount of brittle if / else statements all over the place).

I ran the Kubernetes conformance tests (123 Passed | 0 Failed) against this new cluster config in two separate regions without issue. I've also did some additional manual testing around pod networking since I made some additional changes in that area to reduce some duplicate code.

Once this is merged, we should probably create a new tag so that v.1.0.0 can be the "initial" release that supported Ubuntu and this would be a subsequent release that supports OEL.