### PR TITLE
Correct flanneld settings

### DIFF
--- a/instances/k8smaster/scripts/flannel.service
+++ b/instances/k8smaster/scripts/flannel.service
@@ -5,6 +5,7 @@ Documentation=https://github.com/coreos/flannel
 [Service]
 Type=notify
 ExecStart=/usr/local/bin/flanneld \
+  -ip-masq=true \
   -iface $IP_LOCAL \
   -etcd-endpoints $ETCD_SERVER \
   -etcd-prefix /flannel/network

--- a/instances/k8smaster/scripts/flannel.service
+++ b/instances/k8smaster/scripts/flannel.service
@@ -11,6 +11,7 @@ ExecStart=/usr/local/bin/flanneld \
   -etcd-prefix /flannel/network
 Restart=always
 RestartSec=10
+After=docker.service kubelet.service
 
 [Install]
 WantedBy=multi-user.target

--- a/instances/k8smaster/scripts/setup.template.sh
+++ b/instances/k8smaster/scripts/setup.template.sh
@@ -114,6 +114,8 @@ systemctl start kubelet
 
 until kubectl get all; do sleep 1 && echo -n "."; done
 
+systemctl restart flannel
+
 ## Wait for k8s master to be available. There is a possible race on pod networks otherwise.
 until [ "$(curl localhost:8080/healthz 2>/dev/null)" == "ok" ]; do
 	sleep 3

--- a/instances/k8sworker/scripts/flannel.service
+++ b/instances/k8sworker/scripts/flannel.service
@@ -5,6 +5,7 @@ Documentation=https://github.com/coreos/flannel
 [Service]
 Type=notify
 ExecStart=/usr/local/bin/flanneld \
+  -ip-masq=true \
   -iface $IP_LOCAL \
   -etcd-endpoints $ETCD_SERVER \
   -etcd-prefix /flannel/network

--- a/instances/k8sworker/scripts/flannel.service
+++ b/instances/k8sworker/scripts/flannel.service
@@ -11,6 +11,7 @@ ExecStart=/usr/local/bin/flanneld \
   -etcd-prefix /flannel/network
 Restart=always
 RestartSec=10
+After=docker.service kubelet.service
 
 [Install]
 WantedBy=multi-user.target

--- a/instances/k8sworker/scripts/setup.template.sh
+++ b/instances/k8sworker/scripts/setup.template.sh
@@ -151,5 +151,7 @@ systemctl daemon-reload
 systemctl enable kubelet
 systemctl start kubelet
 
+systemctl restart flannel
+
 ######################################
 echo "Finished running setup.sh"


### PR DESCRIPTION
For correct k8s operation, ip-masq must be turned *off* for dockerd
but it must be turned *on* for flanneld.