### PR TITLE
Jrosinsk/wip make etcd load balancer optional poc

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ k8sWorkerAd3Count                   | 0                       | number of k8s wo
 etcdAd1Count                        | 1                       | number of etcd nodes to create in AD1
 etcdAd2Count                        | 0                       | number of etcd nodes to create in AD2
 etcdAd3Count                        | 0                       | number of etcd nodes to create in AD3
+etcdLBEnabled                       | "true"                  | can disable the etcd Load Balancer
 etcdLBShape                         | 100Mbps                 | etcd OCI Load Balancer shape / bandwidth
 k8sMasterLBShape                    | 100Mbps                 | master OCI Load Balancer shape / bandwidth
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ k8sWorkerAd3Count                   | 0                       | number of k8s wo
 etcdAd1Count                        | 1                       | number of etcd nodes to create in AD1
 etcdAd2Count                        | 0                       | number of etcd nodes to create in AD2
 etcdAd3Count                        | 0                       | number of etcd nodes to create in AD3
-etcdLBEnabled                       | "true"                  | can disable the etcd Load Balancer
+etcd_lb_enabled                     | "true"                  | enable/disable the etcd load balancer. "true" use the etcd load balancer ip, "false" use a list of etcd instance ips
 etcdLBShape                         | 100Mbps                 | etcd OCI Load Balancer shape / bandwidth
 k8sMasterLBShape                    | 100Mbps                 | master OCI Load Balancer shape / bandwidth
 

--- a/instances/etcd/cloud_init/bootstrap.template.sh
+++ b/instances/etcd/cloud_init/bootstrap.template.sh
@@ -46,7 +46,7 @@ docker run -d \
 	-discovery ${etcd_discovery_url}
 
 # Download etcdctl client etcd_ver
-curl -L --retry 3 https://github.com/coreos/etcd/releases/download/${etcd_ver}/etcd-${etcd_ver}-linux-amd64.tar.gz -o /tmp/etcd-${etcd_ver}-linux-amd64.tar.gz
+curl -L --retry 10 https://github.com/coreos/etcd/releases/download/${etcd_ver}/etcd-${etcd_ver}-linux-amd64.tar.gz -o /tmp/etcd-${etcd_ver}-linux-amd64.tar.gz
 tar zxf /tmp/etcd-${etcd_ver}-linux-amd64.tar.gz -C /tmp/ && cp /tmp/etcd-${etcd_ver}-linux-amd64/etcd* /usr/local/bin/
 
 # Generate a flannel configuration JSON that we will store into etcd using curl.

--- a/instances/etcd/cloud_init/bootstrap.template.sh
+++ b/instances/etcd/cloud_init/bootstrap.template.sh
@@ -46,7 +46,7 @@ docker run -d \
 	-discovery ${etcd_discovery_url}
 
 # Download etcdctl client etcd_ver
-curl -L --retry 10 https://github.com/coreos/etcd/releases/download/${etcd_ver}/etcd-${etcd_ver}-linux-amd64.tar.gz -o /tmp/etcd-${etcd_ver}-linux-amd64.tar.gz
+curl -L --retry 5 https://github.com/coreos/etcd/releases/download/${etcd_ver}/etcd-${etcd_ver}-linux-amd64.tar.gz -o /tmp/etcd-${etcd_ver}-linux-amd64.tar.gz
 tar zxf /tmp/etcd-${etcd_ver}-linux-amd64.tar.gz -C /tmp/ && cp /tmp/etcd-${etcd_ver}-linux-amd64/etcd* /usr/local/bin/
 
 # Generate a flannel configuration JSON that we will store into etcd using curl.

--- a/instances/etcd/outputs.tf
+++ b/instances/etcd/outputs.tf
@@ -15,3 +15,4 @@ output "private_ips" {
 output "instance_public_ips" {
   value = ["${oci_core_instance.TFInstanceEtcd.*.public_ip}"]
 }
+ 

--- a/instances/k8smaster/datasources.tf
+++ b/instances/k8smaster/datasources.tf
@@ -19,8 +19,8 @@ data "template_file" "setup-template" {
     etcd_ver           = "${var.etcd_ver}"
     flannel_ver        = "${var.flannel_ver}"
     k8s_ver            = "${var.k8s_ver}"
-    etcd_lb            = "${var.etcd_lb}"
     etcd_discovery_url = "${file("${path.root}/generated/discovery${var.etcd_discovery_url}")}"
+    etcd_endpoints     = "${var.etcd_endpoints}"
   }
 }
 
@@ -37,9 +37,9 @@ data "template_file" "kube-apiserver" {
 
   vars = {
     api_server_count = "${var.api_server_count}"
-    etcd_lb          = "${var.etcd_lb}"
     domain_name      = "${var.domain_name}"
     k8s_ver          = "${var.k8s_ver}"
+    etcd_endpoints   = "${var.etcd_endpoints}"
   }
 }
 

--- a/instances/k8smaster/manifests/kube-apiserver.yaml
+++ b/instances/k8smaster/manifests/kube-apiserver.yaml
@@ -12,7 +12,7 @@ spec:
     - /hyperkube
     - apiserver
     - --apiserver-count=${api_server_count}
-    - --etcd-servers=${etcd_lb}
+    - --etcd-servers=${etcd_endpoints}
     - --allow-privileged=true
     - --service-cluster-ip-range=10.21.0.0/16
     - --secure-port=443

--- a/instances/k8smaster/variables.tf
+++ b/instances/k8smaster/variables.tf
@@ -51,7 +51,7 @@ variable "k8s_dns_ver" {
 }
 
 variable "api_server_count" {}
-variable "etcd_lb" {}
+
 variable "root_ca_pem" {}
 variable "api_server_private_key_pem" {}
 variable "api_server_cert_pem" {}
@@ -59,3 +59,4 @@ variable "k8s_apiserver_token_admin" {}
 
 # etcd
 variable "etcd_discovery_url" {}
+variable "etcd_endpoints" {}

--- a/instances/k8sworker/datasources.tf
+++ b/instances/k8sworker/datasources.tf
@@ -20,8 +20,8 @@ data "template_file" "setup-template" {
     etcd_ver           = "${var.etcd_ver}"
     flannel_ver        = "${var.flannel_ver}"
     k8s_ver            = "${var.k8s_ver}"
-    etcd_lb            = "${var.etcd_lb}"
     etcd_discovery_url = "${file("${path.root}/generated/discovery${var.etcd_discovery_url}")}"
+    etcd_endpoints     = "${var.etcd_endpoints}"
   }
 }
 

--- a/instances/k8sworker/scripts/setup.template.sh
+++ b/instances/k8sworker/scripts/setup.template.sh
@@ -10,7 +10,7 @@ curl -sL --retry 3 http://169.254.169.254/opc/v1/instance/ | tee /tmp/instance_m
 ## Create policy file that blocks autostart of services on install
 printf '#!/bin/sh\necho "All runlevel operations denied by policy" >&2\nexit 101\n' >/tmp/policy-rc.d && chmod +x /tmp/policy-rc.d
 export K8S_API_SERVER_LB=${master_lb}
-export ETCD_LB=${etcd_lb}
+export ETCD_ENDPOINTS=${etcd_endpoints}
 export RANDFILE=$(mktemp)
 export HOSTNAME=$(hostname)
 
@@ -27,7 +27,7 @@ curl -L --retry 3 https://github.com/coreos/etcd/releases/download/${etcd_ver}/e
 tar zxf /tmp/etcd-${etcd_ver}-linux-amd64.tar.gz -C /tmp/ && cp /tmp/etcd-${etcd_ver}-linux-amd64/etcd* /usr/local/bin/
 
 # Wait for etcd to become active (through the LB)
-until [ $(/usr/local/bin/etcdctl --endpoints ${etcd_lb} cluster-health | grep '^cluster ' | grep -c 'is healthy$') == "1" ]; do
+until [ $(/usr/local/bin/etcdctl --endpoints ${etcd_endpoints} cluster-health | grep '^cluster ' | grep -c 'is healthy$') == "1" ]; do
 	echo "Waiting for etcd cluster to be healthy"
 	sleep 1
 done
@@ -36,7 +36,7 @@ done
 ######################################
 curl -L --retry 3 https://github.com/coreos/flannel/releases/download/${flannel_ver}/flanneld-amd64 -o /usr/local/bin/flanneld \
 	&& chmod 755 /usr/local/bin/flanneld
-export ETCD_SERVER=${etcd_lb}
+export ETCD_SERVER=${etcd_endpoints}
 echo "IP_LOCAL: $IP_LOCAL ETCD_SERVER: $ETCD_SERVER"
 envsubst </root/services/flannel.service >/etc/systemd/system/flannel.service
 systemctl daemon-reload && systemctl enable flannel && systemctl start flannel
@@ -62,7 +62,7 @@ systemctl start docker
 ## Output /etc/environment_params
 ######################################
 echo "IPV4_PRIVATE_0=$IP_LOCAL" >>/etc/environment_params
-echo "ETCD_IP=$ETCD_LB" >>/etc/environment_params
+echo "ETCD_IP=$ETCD_ENDPOINTS" >>/etc/environment_params
 echo "K8S_API_SERVER_LB=$K8S_API_SERVER_LB" >>/etc/environment_params
 echo "FQDN_HOSTNAME=$FQDN_HOSTNAME" >>/etc/environment_params
 

--- a/instances/k8sworker/variables.tf
+++ b/instances/k8sworker/variables.tf
@@ -32,8 +32,6 @@ variable "instance_os_ver" {
   default = "7.4"
 }
 
-variable "etcd_lb" {}
-
 variable "etcd_ver" {
   default = "v3.2.2"
 }
@@ -57,3 +55,4 @@ variable "api_server_cert_pem" {}
 
 # etcd
 variable "etcd_discovery_url" {}
+variable "etcd_endpoints" {}

--- a/k8s-oci.tf
+++ b/k8s-oci.tf
@@ -275,7 +275,7 @@ module "instances-k8smaster-ad1" {
   ssh_public_key_openssh     = "${module.k8s-tls.ssh_public_key_openssh}"
   subnet_id                  = "${module.subnet-k8sMasterSubnetAd1.id}"
   tenancy_ocid               = "${var.compartment_ocid}"
-  etcd_endpoints             = "${var.etcdLBEnabled=="true" ?
+  etcd_endpoints             = "${var.etcd_lb_enabled=="true" ?
                                     join(",",formatlist("http://%s:2379",
                                                               module.etcd-private-lb.ip_addresses)):
                                     join(",",formatlist("http://%s:2379",compact(concat(
@@ -310,7 +310,7 @@ module "instances-k8smaster-ad2" {
   ssh_public_key_openssh     = "${module.k8s-tls.ssh_public_key_openssh}"
   subnet_id                  = "${module.subnet-k8sMasterSubnetAd2.id}"
   tenancy_ocid               = "${var.compartment_ocid}"
-  etcd_endpoints             = "${var.etcdLBEnabled=="true" ?
+  etcd_endpoints             = "${var.etcd_lb_enabled=="true" ?
                                     join(",",formatlist("http://%s:2379",
                                                               module.etcd-private-lb.ip_addresses)) :
                                     join(",",formatlist("http://%s:2379",compact(concat(
@@ -345,7 +345,7 @@ module "instances-k8smaster-ad3" {
   ssh_public_key_openssh     = "${module.k8s-tls.ssh_public_key_openssh}"
   subnet_id                  = "${module.subnet-k8sMasterSubnetAd3.id}"
   tenancy_ocid               = "${var.compartment_ocid}"
-  etcd_endpoints             = "${var.etcdLBEnabled=="true" ?
+  etcd_endpoints             = "${var.etcd_lb_enabled=="true" ?
                                     join(",",formatlist("http://%s:2379",
                                                               module.etcd-private-lb.ip_addresses)):
                                     join(",",formatlist("http://%s:2379",compact(concat(
@@ -380,7 +380,7 @@ module "instances-k8sworker-ad1" {
   ssh_public_key_openssh     = "${module.k8s-tls.ssh_public_key_openssh}"
   subnet_id                  = "${module.subnet-k8sWorkerSubnetAd1.id}"
   tenancy_ocid               = "${var.compartment_ocid}"
-  etcd_endpoints             = "${var.etcdLBEnabled=="true" ?
+  etcd_endpoints             = "${var.etcd_lb_enabled=="true" ?
                                     join(",",formatlist("http://%s:2379",
                                                               module.etcd-private-lb.ip_addresses)):
                                     join(",",formatlist("http://%s:2379",compact(concat(
@@ -415,7 +415,7 @@ module "instances-k8sworker-ad2" {
   ssh_public_key_openssh     = "${module.k8s-tls.ssh_public_key_openssh}"
   subnet_id                  = "${module.subnet-k8sWorkerSubnetAd2.id}"
   tenancy_ocid               = "${var.compartment_ocid}"
-  etcd_endpoints             = "${var.etcdLBEnabled=="true" ?
+  etcd_endpoints             = "${var.etcd_lb_enabled=="true" ?
                                     join(",",formatlist("http://%s:2379",
                                                               module.etcd-private-lb.ip_addresses)):
                                     join(",",formatlist("http://%s:2379",compact(concat(
@@ -450,7 +450,7 @@ module "instances-k8sworker-ad3" {
   ssh_public_key_openssh     = "${module.k8s-tls.ssh_public_key_openssh}"
   subnet_id                  = "${module.subnet-k8sWorkerSubnetAd3.id}"
   tenancy_ocid               = "${var.compartment_ocid}"
-  etcd_endpoints             = "${var.etcdLBEnabled=="true" ?
+  etcd_endpoints             = "${var.etcd_lb_enabled=="true" ?
                                     join(",",formatlist("http://%s:2379",
                                                               module.etcd-private-lb.ip_addresses)):
                                     join(",",formatlist("http://%s:2379",compact(concat(
@@ -463,8 +463,8 @@ module "instances-k8sworker-ad3" {
 
 module "etcd-private-lb" {
   source               = "loadbalancers/etcd"
-  count                = "${var.etcdLBEnabled=="true"? 1 : 0 }"
-  etcdLBEnabled        = "${var.etcdLBEnabled}"
+  count                = "${var.etcd_lb_enabled=="true"? 1 : 0 }"
+  etcd_lb_enabled        = "${var.etcd_lb_enabled}"
   compartment_ocid     = "${var.compartment_ocid}"
   etcd_subnet_0_id     = "${module.subnet-etcd-ad1.id}"
   etcd_ad1_private_ips = "${module.instances-etcd-ad1.private_ips}"

--- a/k8s-oci.tf
+++ b/k8s-oci.tf
@@ -262,7 +262,6 @@ module "instances-k8smaster-ad1" {
   docker_ver                 = "${var.docker_ver}"
   domain_name                = "${var.domain_name}"
   etcd_discovery_url         = "${template_file.etcd_discovery_url.id}"
-  etcd_lb                    = "http://${module.etcd-private-lb.ip_addresses[0]}:2379"
   etcd_ver                   = "${var.etcd_ver}"
   flannel_ver                = "${var.flannel_ver}"
   hostname_label_prefix      = "k8s-master-ad1"
@@ -276,6 +275,13 @@ module "instances-k8smaster-ad1" {
   ssh_public_key_openssh     = "${module.k8s-tls.ssh_public_key_openssh}"
   subnet_id                  = "${module.subnet-k8sMasterSubnetAd1.id}"
   tenancy_ocid               = "${var.compartment_ocid}"
+  etcd_endpoints             = "${var.etcdLBEnabled=="true" ?
+                                    join(",",formatlist("http://%s:2379",
+                                                              module.etcd-private-lb.ip_addresses)):
+                                    join(",",formatlist("http://%s:2379",compact(concat(
+                                                              module.instances-etcd-ad1.private_ips,
+                                                              module.instances-etcd-ad2.private_ips,
+                                                              module.instances-etcd-ad3.private_ips)))) }"
 }
 
 module "instances-k8smaster-ad2" {
@@ -291,7 +297,6 @@ module "instances-k8smaster-ad2" {
   docker_ver                 = "${var.docker_ver}"
   domain_name                = "${var.domain_name}"
   etcd_discovery_url         = "${template_file.etcd_discovery_url.id}"
-  etcd_lb                    = "http://${module.etcd-private-lb.ip_addresses[0]}:2379"
   etcd_ver                   = "${var.etcd_ver}"
   flannel_ver                = "${var.flannel_ver}"
   hostname_label_prefix      = "k8s-master-ad2"
@@ -305,6 +310,13 @@ module "instances-k8smaster-ad2" {
   ssh_public_key_openssh     = "${module.k8s-tls.ssh_public_key_openssh}"
   subnet_id                  = "${module.subnet-k8sMasterSubnetAd2.id}"
   tenancy_ocid               = "${var.compartment_ocid}"
+  etcd_endpoints             = "${var.etcdLBEnabled=="true" ?
+                                    join(",",formatlist("http://%s:2379",
+                                                              module.etcd-private-lb.ip_addresses)) :
+                                    join(",",formatlist("http://%s:2379",compact(concat(
+                                                              module.instances-etcd-ad1.private_ips,
+                                                              module.instances-etcd-ad2.private_ips,
+                                                              module.instances-etcd-ad3.private_ips)))) }"
 }
 
 module "instances-k8smaster-ad3" {
@@ -320,7 +332,6 @@ module "instances-k8smaster-ad3" {
   docker_ver                 = "${var.docker_ver}"
   domain_name                = "${var.domain_name}"
   etcd_discovery_url         = "${template_file.etcd_discovery_url.id}"
-  etcd_lb                    = "http://${module.etcd-private-lb.ip_addresses[0]}:2379"
   etcd_ver                   = "${var.etcd_ver}"
   flannel_ver                = "${var.flannel_ver}"
   hostname_label_prefix      = "k8s-master-ad3"
@@ -334,6 +345,13 @@ module "instances-k8smaster-ad3" {
   ssh_public_key_openssh     = "${module.k8s-tls.ssh_public_key_openssh}"
   subnet_id                  = "${module.subnet-k8sMasterSubnetAd3.id}"
   tenancy_ocid               = "${var.compartment_ocid}"
+  etcd_endpoints             = "${var.etcdLBEnabled=="true" ?
+                                    join(",",formatlist("http://%s:2379",
+                                                              module.etcd-private-lb.ip_addresses)):
+                                    join(",",formatlist("http://%s:2379",compact(concat(
+                                                              module.instances-etcd-ad1.private_ips,
+                                                              module.instances-etcd-ad2.private_ips,
+                                                              module.instances-etcd-ad3.private_ips)))) }"
 }
 
 module "instances-k8sworker-ad1" {
@@ -347,7 +365,6 @@ module "instances-k8sworker-ad1" {
   docker_ver                 = "${var.docker_ver}"
   domain_name                = "${var.domain_name}"
   etcd_discovery_url         = "${template_file.etcd_discovery_url.id}"
-  etcd_lb                    = "http://${module.etcd-private-lb.ip_addresses[0]}:2379"
   etcd_ver                   = "${var.etcd_ver}"
   flannel_ver                = "${var.flannel_ver}"
   hostname_label_prefix      = "k8s-worker-ad1"
@@ -363,6 +380,13 @@ module "instances-k8sworker-ad1" {
   ssh_public_key_openssh     = "${module.k8s-tls.ssh_public_key_openssh}"
   subnet_id                  = "${module.subnet-k8sWorkerSubnetAd1.id}"
   tenancy_ocid               = "${var.compartment_ocid}"
+  etcd_endpoints             = "${var.etcdLBEnabled=="true" ?
+                                    join(",",formatlist("http://%s:2379",
+                                                              module.etcd-private-lb.ip_addresses)):
+                                    join(",",formatlist("http://%s:2379",compact(concat(
+                                                              module.instances-etcd-ad1.private_ips,
+                                                              module.instances-etcd-ad2.private_ips,
+                                                              module.instances-etcd-ad3.private_ips)))) }"
 }
 
 module "instances-k8sworker-ad2" {
@@ -376,7 +400,6 @@ module "instances-k8sworker-ad2" {
   docker_ver                 = "${var.docker_ver}"
   domain_name                = "${var.domain_name}"
   etcd_discovery_url         = "${template_file.etcd_discovery_url.id}"
-  etcd_lb                    = "http://${module.etcd-private-lb.ip_addresses[0]}:2379"
   etcd_ver                   = "${var.etcd_ver}"
   flannel_ver                = "${var.flannel_ver}"
   hostname_label_prefix      = "k8s-worker-ad2"
@@ -392,6 +415,13 @@ module "instances-k8sworker-ad2" {
   ssh_public_key_openssh     = "${module.k8s-tls.ssh_public_key_openssh}"
   subnet_id                  = "${module.subnet-k8sWorkerSubnetAd2.id}"
   tenancy_ocid               = "${var.compartment_ocid}"
+  etcd_endpoints             = "${var.etcdLBEnabled=="true" ?
+                                    join(",",formatlist("http://%s:2379",
+                                                              module.etcd-private-lb.ip_addresses)):
+                                    join(",",formatlist("http://%s:2379",compact(concat(
+                                                              module.instances-etcd-ad1.private_ips,
+                                                              module.instances-etcd-ad2.private_ips,
+                                                              module.instances-etcd-ad3.private_ips)))) }"
 }
 
 module "instances-k8sworker-ad3" {
@@ -405,11 +435,10 @@ module "instances-k8sworker-ad3" {
   docker_ver                 = "${var.docker_ver}"
   domain_name                = "${var.domain_name}"
   etcd_discovery_url         = "${template_file.etcd_discovery_url.id}"
-  etcd_lb                    = "http://${module.etcd-private-lb.ip_addresses[0]}:2379"
   etcd_ver                   = "${var.etcd_ver}"
   flannel_ver                = "${var.flannel_ver}"
   hostname_label_prefix      = "k8s-worker-ad3"
-  instance_os_ver           = "${var.instance_os_ver}"
+  instance_os_ver            = "${var.instance_os_ver}"
   k8s_ver                    = "${var.k8s_ver}"
   label_prefix               = "${var.label_prefix}"
   master_lb                  = "https://${module.k8smaster-public-lb.ip_addresses[0]}:443"
@@ -421,12 +450,21 @@ module "instances-k8sworker-ad3" {
   ssh_public_key_openssh     = "${module.k8s-tls.ssh_public_key_openssh}"
   subnet_id                  = "${module.subnet-k8sWorkerSubnetAd3.id}"
   tenancy_ocid               = "${var.compartment_ocid}"
+  etcd_endpoints             = "${var.etcdLBEnabled=="true" ?
+                                    join(",",formatlist("http://%s:2379",
+                                                              module.etcd-private-lb.ip_addresses)):
+                                    join(",",formatlist("http://%s:2379",compact(concat(
+                                                              module.instances-etcd-ad1.private_ips,
+                                                              module.instances-etcd-ad2.private_ips,
+                                                              module.instances-etcd-ad3.private_ips)))) }"
 }
 
 ### Load Balancers
 
 module "etcd-private-lb" {
   source               = "loadbalancers/etcd"
+  count                = "${var.etcdLBEnabled=="true"? 1 : 0 }"
+  etcdLBEnabled        = "${var.etcdLBEnabled}"
   compartment_ocid     = "${var.compartment_ocid}"
   etcd_subnet_0_id     = "${module.subnet-etcd-ad1.id}"
   etcd_ad1_private_ips = "${module.instances-etcd-ad1.private_ips}"
@@ -460,3 +498,5 @@ module "kubeconfig" {
   api_server_cert_pem        = "${module.k8s-tls.api_server_cert_pem}"
   k8s_master                 = "https://${module.k8smaster-public-lb.ip_addresses[0]}:443"
 }
+
+

--- a/loadbalancers/etcd/main.tf
+++ b/loadbalancers/etcd/main.tf
@@ -121,7 +121,7 @@ resource "oci_load_balancer_backend" "etcd-2380-backends-ad2" {
 resource "oci_load_balancer_backend" "etcd-2380-backends-ad3" {
   load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
   backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.name)}"
-  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd2Count }"
+  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd3Count }"
   ip_address       = "${var.count==0?" ":element(var.etcd_ad3_private_ips, count.index)}"
   port             = "2380"
   backup           = false

--- a/loadbalancers/etcd/main.tf
+++ b/loadbalancers/etcd/main.tf
@@ -91,9 +91,6 @@ resource "oci_load_balancer_backend" "etcd-2379-backends-ad3" {
   weight           = 1
 }
 
-# element workaround
-#propagating_vgws = ["${compact(split(",", var.vpc_vpg == "true" && var.subnet_public_route_vpg == "true" ? join("", aws_vpn_gateway.vpg.*.id) : join("", list(""))))}"]
-#
 resource "oci_load_balancer_backend" "etcd-2380-backends-ad1" {
   load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
   backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.name)}"

--- a/loadbalancers/etcd/main.tf
+++ b/loadbalancers/etcd/main.tf
@@ -1,4 +1,5 @@
 resource "oci_load_balancer" "lb-etcd" {
+  count          = "${var.count}"
   shape          = "${var.shape}"
   compartment_id = "${var.compartment_ocid}"
 
@@ -11,8 +12,9 @@ resource "oci_load_balancer" "lb-etcd" {
 }
 
 resource "oci_load_balancer_backendset" "lb-etcd-backendset-2379" {
+  count            = "${var.count}"
   name             = "lb-backendset-etcd-2379"
-  load_balancer_id = "${oci_load_balancer.lb-etcd.id}"
+  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
   policy           = "ROUND_ROBIN"
 
   health_checker {
@@ -23,8 +25,9 @@ resource "oci_load_balancer_backendset" "lb-etcd-backendset-2379" {
 }
 
 resource "oci_load_balancer_backendset" "lb-etcd-backendset-2380" {
+  count            = "${var.count}"
   name             = "lb-backendset-etcd-2380"
-  load_balancer_id = "${oci_load_balancer.lb-etcd.id}"
+  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
   policy           = "ROUND_ROBIN"
 
   health_checker {
@@ -35,26 +38,28 @@ resource "oci_load_balancer_backendset" "lb-etcd-backendset-2380" {
 }
 
 resource "oci_load_balancer_listener" "port-2379" {
-  load_balancer_id         = "${oci_load_balancer.lb-etcd.id}"
+  count                    = "${var.count}"
+  load_balancer_id         = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
   name                     = "port-2379"
-  default_backend_set_name = "${oci_load_balancer_backendset.lb-etcd-backendset-2379.id}"
+  default_backend_set_name = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2379.*.id)}"
   port                     = 2379
   protocol                 = "TCP"
 }
 
 resource "oci_load_balancer_listener" "port-2380" {
-  load_balancer_id         = "${oci_load_balancer.lb-etcd.id}"
+  count                    = "${var.count}"
+  load_balancer_id         = "${var.count == 0?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
   name                     = "port-2380"
-  default_backend_set_name = "${oci_load_balancer_backendset.lb-etcd-backendset-2380.id}"
+  default_backend_set_name = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.id)}"
   port                     = 2380
   protocol                 = "TCP"
 }
 
 resource "oci_load_balancer_backend" "etcd-2379-backends-ad1" {
-  load_balancer_id = "${oci_load_balancer.lb-etcd.id}"
-  backendset_name  = "${oci_load_balancer_backendset.lb-etcd-backendset-2379.name}"
-  count            = "${var.etcdAd1Count}"
-  ip_address       = "${element(var.etcd_ad1_private_ips, count.index)}"
+  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2379.*.name)}"
+  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd1Count }"
+  ip_address       = "${var.count==0?" ":element(var.etcd_ad1_private_ips, count.index)}"
   port             = "2379"
   backup           = false
   drain            = false
@@ -63,10 +68,10 @@ resource "oci_load_balancer_backend" "etcd-2379-backends-ad1" {
 }
 
 resource "oci_load_balancer_backend" "etcd-2379-backends-ad2" {
-  load_balancer_id = "${oci_load_balancer.lb-etcd.id}"
-  backendset_name  = "${oci_load_balancer_backendset.lb-etcd-backendset-2379.name}"
-  count            = "${var.etcdAd2Count}"
-  ip_address       = "${element(var.etcd_ad2_private_ips, count.index)}"
+  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2379.*.name)}"
+  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd2Count }"
+  ip_address       = "${var.count==0?" ":element(var.etcd_ad2_private_ips, count.index)}"
   port             = "2379"
   backup           = false
   drain            = false
@@ -75,10 +80,10 @@ resource "oci_load_balancer_backend" "etcd-2379-backends-ad2" {
 }
 
 resource "oci_load_balancer_backend" "etcd-2379-backends-ad3" {
-  load_balancer_id = "${oci_load_balancer.lb-etcd.id}"
-  backendset_name  = "${oci_load_balancer_backendset.lb-etcd-backendset-2379.name}"
-  count            = "${var.etcdAd3Count}"
-  ip_address       = "${element(var.etcd_ad3_private_ips, count.index)}"
+  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2379.*.name)}"
+  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd3Count }"
+  ip_address       = "${var.count==0?" ":element(var.etcd_ad3_private_ips, count.index)}"
   port             = "2379"
   backup           = false
   drain            = false
@@ -86,11 +91,14 @@ resource "oci_load_balancer_backend" "etcd-2379-backends-ad3" {
   weight           = 1
 }
 
+# element workaround
+#propagating_vgws = ["${compact(split(",", var.vpc_vpg == "true" && var.subnet_public_route_vpg == "true" ? join("", aws_vpn_gateway.vpg.*.id) : join("", list(""))))}"]
+#
 resource "oci_load_balancer_backend" "etcd-2380-backends-ad1" {
-  load_balancer_id = "${oci_load_balancer.lb-etcd.id}"
-  backendset_name  = "${oci_load_balancer_backendset.lb-etcd-backendset-2380.name}"
-  count            = "${var.etcdAd1Count}"
-  ip_address       = "${element(var.etcd_ad1_private_ips, count.index)}"
+  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.name)}"
+  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd1Count }"
+  ip_address       = "${var.count==0?" ":element(var.etcd_ad1_private_ips, count.index)}"
   port             = "2380"
   backup           = false
   drain            = false
@@ -99,10 +107,10 @@ resource "oci_load_balancer_backend" "etcd-2380-backends-ad1" {
 }
 
 resource "oci_load_balancer_backend" "etcd-2380-backends-ad2" {
-  load_balancer_id = "${oci_load_balancer.lb-etcd.id}"
-  backendset_name  = "${oci_load_balancer_backendset.lb-etcd-backendset-2380.name}"
-  count            = "${var.etcdAd2Count}"
-  ip_address       = "${element(var.etcd_ad2_private_ips, count.index)}"
+  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.name)}"
+  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd2Count }"
+  ip_address       = "${var.count==0?" ":element(var.etcd_ad2_private_ips, count.index)}"
   port             = "2380"
   backup           = false
   drain            = false
@@ -111,10 +119,10 @@ resource "oci_load_balancer_backend" "etcd-2380-backends-ad2" {
 }
 
 resource "oci_load_balancer_backend" "etcd-2380-backends-ad3" {
-  load_balancer_id = "${oci_load_balancer.lb-etcd.id}"
-  backendset_name  = "${oci_load_balancer_backendset.lb-etcd-backendset-2380.name}"
-  count            = "${var.etcdAd3Count}"
-  ip_address       = "${element(var.etcd_ad3_private_ips, count.index)}"
+  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.name)}"
+  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd2Count }"
+  ip_address       = "${var.count==0?" ":element(var.etcd_ad3_private_ips, count.index)}"
   port             = "2380"
   backup           = false
   drain            = false

--- a/loadbalancers/etcd/main.tf
+++ b/loadbalancers/etcd/main.tf
@@ -14,7 +14,7 @@ resource "oci_load_balancer" "lb-etcd" {
 resource "oci_load_balancer_backendset" "lb-etcd-backendset-2379" {
   count            = "${var.count}"
   name             = "lb-backendset-etcd-2379"
-  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  load_balancer_id = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
   policy           = "ROUND_ROBIN"
 
   health_checker {
@@ -27,7 +27,7 @@ resource "oci_load_balancer_backendset" "lb-etcd-backendset-2379" {
 resource "oci_load_balancer_backendset" "lb-etcd-backendset-2380" {
   count            = "${var.count}"
   name             = "lb-backendset-etcd-2380"
-  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  load_balancer_id = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
   policy           = "ROUND_ROBIN"
 
   health_checker {
@@ -39,9 +39,9 @@ resource "oci_load_balancer_backendset" "lb-etcd-backendset-2380" {
 
 resource "oci_load_balancer_listener" "port-2379" {
   count                    = "${var.count}"
-  load_balancer_id         = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  load_balancer_id         = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
   name                     = "port-2379"
-  default_backend_set_name = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2379.*.id)}"
+  default_backend_set_name = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2379.*.id)}"
   port                     = 2379
   protocol                 = "TCP"
 }
@@ -50,15 +50,15 @@ resource "oci_load_balancer_listener" "port-2380" {
   count                    = "${var.count}"
   load_balancer_id         = "${var.count == 0?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
   name                     = "port-2380"
-  default_backend_set_name = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.id)}"
+  default_backend_set_name = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.id)}"
   port                     = 2380
   protocol                 = "TCP"
 }
 
 resource "oci_load_balancer_backend" "etcd-2379-backends-ad1" {
-  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
-  backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2379.*.name)}"
-  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd1Count }"
+  load_balancer_id = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  backendset_name  = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2379.*.name)}"
+  count            = "${var.etcd_lb_enabled=="false" ? 0 : var.etcdAd1Count }"
   ip_address       = "${var.count==0?" ":element(var.etcd_ad1_private_ips, count.index)}"
   port             = "2379"
   backup           = false
@@ -68,9 +68,9 @@ resource "oci_load_balancer_backend" "etcd-2379-backends-ad1" {
 }
 
 resource "oci_load_balancer_backend" "etcd-2379-backends-ad2" {
-  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
-  backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2379.*.name)}"
-  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd2Count }"
+  load_balancer_id = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  backendset_name  = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2379.*.name)}"
+  count            = "${var.etcd_lb_enabled=="false" ? 0 : var.etcdAd2Count }"
   ip_address       = "${var.count==0?" ":element(var.etcd_ad2_private_ips, count.index)}"
   port             = "2379"
   backup           = false
@@ -80,9 +80,9 @@ resource "oci_load_balancer_backend" "etcd-2379-backends-ad2" {
 }
 
 resource "oci_load_balancer_backend" "etcd-2379-backends-ad3" {
-  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
-  backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2379.*.name)}"
-  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd3Count }"
+  load_balancer_id = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  backendset_name  = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2379.*.name)}"
+  count            = "${var.etcd_lb_enabled=="false" ? 0 : var.etcdAd3Count }"
   ip_address       = "${var.count==0?" ":element(var.etcd_ad3_private_ips, count.index)}"
   port             = "2379"
   backup           = false
@@ -92,9 +92,9 @@ resource "oci_load_balancer_backend" "etcd-2379-backends-ad3" {
 }
 
 resource "oci_load_balancer_backend" "etcd-2380-backends-ad1" {
-  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
-  backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.name)}"
-  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd1Count }"
+  load_balancer_id = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  backendset_name  = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.name)}"
+  count            = "${var.etcd_lb_enabled=="false" ? 0 : var.etcdAd1Count }"
   ip_address       = "${var.count==0?" ":element(var.etcd_ad1_private_ips, count.index)}"
   port             = "2380"
   backup           = false
@@ -104,9 +104,9 @@ resource "oci_load_balancer_backend" "etcd-2380-backends-ad1" {
 }
 
 resource "oci_load_balancer_backend" "etcd-2380-backends-ad2" {
-  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
-  backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.name)}"
-  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd2Count }"
+  load_balancer_id = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  backendset_name  = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.name)}"
+  count            = "${var.etcd_lb_enabled=="false" ? 0 : var.etcdAd2Count }"
   ip_address       = "${var.count==0?" ":element(var.etcd_ad2_private_ips, count.index)}"
   port             = "2380"
   backup           = false
@@ -116,9 +116,9 @@ resource "oci_load_balancer_backend" "etcd-2380-backends-ad2" {
 }
 
 resource "oci_load_balancer_backend" "etcd-2380-backends-ad3" {
-  load_balancer_id = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
-  backendset_name  = "${var.etcdLBEnabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.name)}"
-  count            = "${var.etcdLBEnabled=="false" ? 0 : var.etcdAd3Count }"
+  load_balancer_id = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer.lb-etcd.*.id)}"
+  backendset_name  = "${var.etcd_lb_enabled=="false"?" ":join(" ",oci_load_balancer_backendset.lb-etcd-backendset-2380.*.name)}"
+  count            = "${var.etcd_lb_enabled=="false" ? 0 : var.etcdAd3Count }"
   ip_address       = "${var.count==0?" ":element(var.etcd_ad3_private_ips, count.index)}"
   port             = "2380"
   backup           = false

--- a/loadbalancers/etcd/outputs.tf
+++ b/loadbalancers/etcd/outputs.tf
@@ -1,7 +1,7 @@
 # Outputs
 
 output "ip_addresses" {
-  value = ["${oci_load_balancer.lb-etcd.ip_addresses}"]
+  value = ["${join(",",oci_load_balancer.lb-etcd.*.ip_addresses)}"]
 }
 
 output "load_balancer_id" {

--- a/loadbalancers/etcd/outputs.tf
+++ b/loadbalancers/etcd/outputs.tf
@@ -1,7 +1,7 @@
 # Outputs
 
 output "ip_addresses" {
-  value = ["${join(",",oci_load_balancer.lb-etcd.*.ip_addresses)}"]
+  value = ["${flatten(oci_load_balancer.lb-etcd.*.ip_addresses)}"]
 }
 
 output "load_balancer_id" {

--- a/loadbalancers/etcd/variables.tf
+++ b/loadbalancers/etcd/variables.tf
@@ -4,12 +4,17 @@ variable "etcd_subnet_0_id" {}
 variable "label_prefix" {
   default = ""
 }
+variable "count" {
+  default = 1
+}
 
 variable "etcdAd1Count" {}
 
 variable "etcdAd2Count" {}
 
 variable "etcdAd3Count" {}
+
+variable "etcdLBEnabled" {}
 
 variable "etcd_ad1_private_ips" {
   type    = "list"

--- a/loadbalancers/etcd/variables.tf
+++ b/loadbalancers/etcd/variables.tf
@@ -14,7 +14,7 @@ variable "etcdAd2Count" {}
 
 variable "etcdAd3Count" {}
 
-variable "etcdLBEnabled" {}
+variable "etcd_lb_enabled" {}
 
 variable "etcd_ad1_private_ips" {
   type    = "list"

--- a/variables.tf
+++ b/variables.tf
@@ -97,6 +97,11 @@ variable "etcdAd3Count" {
   default = 0
 }
 
+variable "etcd_endpoints" {
+  type="string"
+  default = " "
+}
+
 variable "ssh_public_key_openssh" {
   description = "SSH public key in OpenSSH authorized_keys format for instances (generated if left blank)"
   type        = "string"
@@ -148,6 +153,10 @@ variable "ssh_private_key" {
 # Load Balancers
 variable "etcdLBShape" {
   default = "100Mbps"
+}
+
+variable "etcdLBEnabled" {
+  default = "true"
 }
 
 variable "k8sMasterLBShape" {

--- a/variables.tf
+++ b/variables.tf
@@ -155,7 +155,7 @@ variable "etcdLBShape" {
   default = "100Mbps"
 }
 
-variable "etcdLBEnabled" {
+variable "etcd_lb_enabled" {
   default = "true"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,7 @@ variable "etcdLBShape" {
 }
 
 variable "etcd_lb_enabled" {
+  description = "enable/disable the etcd load balancer. true: use the etcd load balancer ip. false:use a list of etcd instance ips."
   default = "true"
 }
 


### PR DESCRIPTION
Fixes #32 This transaction adds a flag to disable the etcd load balancer if desired. The default behavior is to use the etcd load balancer.  To enable this feature, etcdLBEnabled="false" can be set in the tfvars file. 

Successfully ran the sonobuoy e2e cluster tests on a cluster with this flag enabled.  