### PR TITLE
In moving to OEL the certs are a symlinks. The symlink dest dir needs…

### DIFF
--- a/instances/k8smaster/manifests/kube-controller-manager.yaml
+++ b/instances/k8smaster/manifests/kube-controller-manager.yaml
@@ -35,6 +35,9 @@ spec:
     - mountPath: /etc/ssl/certs
       name: ssl-certs-host
       readOnly: true
+    - mountPath: /etc/pki/certs
+      name: pki-certs-host
+      readOnly: true
     - mountPath: /usr/libexec/kubernetes/kubelet-plugins
       name: plugins
   volumes:
@@ -44,6 +47,9 @@ spec:
   - hostPath:
       path: /etc/ssl/certs
     name: ssl-certs-host
+  - hostPath:
+      path: /etc/pki/certs
+    name: pki-certs-host
   - hostPath:
       path: /usr/libexec/kubernetes/kubelet-plugins
     name: plugins


### PR DESCRIPTION
… mounting in to the container now too.


Signed-off-by: Garth Bushell <garth.bushell@oracle.com>