### PR TITLE
Allow the cni-bridge service to be enabled and start on reboot

### DIFF
--- a/instances/k8smaster/scripts/cni-bridge.service
+++ b/instances/k8smaster/scripts/cni-bridge.service
@@ -5,3 +5,5 @@ Before=docker.service
 Type=oneshot
 ExecStart=/usr/local/bin/cni-bridge.sh
 RemainAfterExit=true
+[Install]
+WantedBy=multi-user.target

--- a/instances/k8sworker/scripts/cni-bridge.service
+++ b/instances/k8sworker/scripts/cni-bridge.service
@@ -5,3 +5,5 @@ Before=docker.service
 Type=oneshot
 ExecStart=/usr/local/bin/cni-bridge.sh
 RemainAfterExit=true
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
If you reboot the master/worker the CNI service doesn't start. This causes the docker service to fail to start. This is bad. 

This fixs the service definition to get installed and started on boot.