### PR TITLE
Make zone consistant accross k8s provisioners

### DIFF
--- a/instances/k8sworker/datasources.tf
+++ b/instances/k8sworker/datasources.tf
@@ -73,8 +73,8 @@ data "template_file" "kubelet-service" {
     master_lb   = "${var.master_lb}"
     k8s_ver     = "${var.k8s_ver}"
     domain_name = "${var.domain_name}"
-    region      = "${lower(var.region)}"
-    zone        = "${lower(replace(var.availability_domain,":","-"))}"
+    region      = "${var.region}"
+    zone        = "${element(split(":",var.availability_domain),1)}"
   }
 }
 


### PR DESCRIPTION
This makes the zone label (failure-domain.beta.kubernetes.io/zone) consistent across k8s provisioners.

This removes the inclusion of tenancy specific information and doesn't lower the string but leaves it as is.

This makes sharing of yaml possible between tenancys when zone placement is needed for volumes/pods