### PR TITLE
WIP: Add fast filesystem for docker

### DIFF
--- a/instances/k8sworker/datasources.tf
+++ b/instances/k8sworker/datasources.tf
@@ -23,6 +23,7 @@ data "template_file" "setup-template" {
     docker_max_log_files = "${var.worker_docker_max_log_files}"
     etcd_discovery_url = "${file("${path.root}/generated/discovery${var.etcd_discovery_url}")}"
     etcd_endpoints     = "${var.etcd_endpoints}"
+    docker_device      = "${var.docker_device}"
   }
 }
 

--- a/instances/k8sworker/scripts/setup.template.sh
+++ b/instances/k8sworker/scripts/setup.template.sh
@@ -49,6 +49,17 @@ systemctl enable cni-bridge && systemctl start cni-bridge
 
 ## Docker
 ######################################
+if [ -n "${docker_device}" ]; then
+  if [ -e "${docker_device}" ]; then
+    mkfs -t xfs -L DOCKER ${docker_device}
+    mkdir -p /var/lib/docker
+    cat <<-EOF >>/etc/fstab
+	LABEL=DOCKER /var/lib/docker  xfs     defaults 0 0
+	EOF
+    mount /var/lib/docker
+  fi
+fi
+
 until yum -y install docker-engine-${docker_ver}; do sleep 1 && echo -n "."; done
 
 cat <<EOF > /etc/sysconfig/docker-network

--- a/instances/k8sworker/variables.tf
+++ b/instances/k8sworker/variables.tf
@@ -65,3 +65,8 @@ variable "worker_docker_max_log_files" {
   description = "Maximum number of the k8s worker docker container json logs to rotate"
   default = "5"
 }
+
+# Docker device
+variable "docker_device" {
+  default = ""
+}

--- a/k8s-oci.tf
+++ b/k8s-oci.tf
@@ -401,6 +401,7 @@ module "instances-k8sworker-ad1" {
                                                               module.instances-etcd-ad1.private_ips,
                                                               module.instances-etcd-ad2.private_ips,
                                                               module.instances-etcd-ad3.private_ips)))) }"
+  docker_device              = "${var.worker_docker_device}"
 }
 
 module "instances-k8sworker-ad2" {
@@ -438,6 +439,7 @@ module "instances-k8sworker-ad2" {
                                                               module.instances-etcd-ad1.private_ips,
                                                               module.instances-etcd-ad2.private_ips,
                                                               module.instances-etcd-ad3.private_ips)))) }"
+  docker_device              = "${var.worker_docker_device}"
 }
 
 module "instances-k8sworker-ad3" {
@@ -475,6 +477,7 @@ module "instances-k8sworker-ad3" {
                                                               module.instances-etcd-ad1.private_ips,
                                                               module.instances-etcd-ad2.private_ips,
                                                               module.instances-etcd-ad3.private_ips)))) }"
+  docker_device              = "${var.worker_docker_device}"
 }
 
 ### Load Balancers

--- a/variables.tf
+++ b/variables.tf
@@ -253,3 +253,7 @@ variable "k8s_dns_ver" {
 variable "oracle_linux_image_name" {
   default = "Oracle-Linux-7.4-2017.10.25-0"
 }
+
+variable "worker_docker_device" {
+  default = ""
+}


### PR DESCRIPTION
This lets you set a single device file which, if present, will be used to
back /var/lib/docker.

The variable should probably be expanded and checked to see if it refers
to multiple devices; under those circmstances we should add all devices
to a VG and build the FS on that. (I was using this on VM.DenseIO1.4, where
there's only a single device.)

It'd be okay to default this to /dev/nvme0n1 since it's a no-op on [VB]M.Standard*
systems.