### PR TITLE
Automaticly detect NVMe disks and put /var/lib/docker on them

### DIFF
--- a/instances/k8sworker/datasources.tf
+++ b/instances/k8sworker/datasources.tf
@@ -23,7 +23,6 @@ data "template_file" "setup-template" {
     docker_max_log_files = "${var.worker_docker_max_log_files}"
     etcd_discovery_url = "${file("${path.root}/generated/discovery${var.etcd_discovery_url}")}"
     etcd_endpoints     = "${var.etcd_endpoints}"
-    docker_device      = "${var.docker_device}"
   }
 }
 

--- a/instances/k8sworker/variables.tf
+++ b/instances/k8sworker/variables.tf
@@ -65,8 +65,3 @@ variable "worker_docker_max_log_files" {
   description = "Maximum number of the k8s worker docker container json logs to rotate"
   default = "5"
 }
-
-# Docker device
-variable "docker_device" {
-  default = ""
-}

--- a/k8s-oci.tf
+++ b/k8s-oci.tf
@@ -258,7 +258,6 @@ module "instances-k8sworker-ad1" {
                                                               module.instances-etcd-ad1.private_ips,
                                                               module.instances-etcd-ad2.private_ips,
                                                               module.instances-etcd-ad3.private_ips)))) }"
-  docker_device              = "${var.worker_docker_device}"
 }
 
 module "instances-k8sworker-ad2" {
@@ -296,7 +295,6 @@ module "instances-k8sworker-ad2" {
                                                               module.instances-etcd-ad1.private_ips,
                                                               module.instances-etcd-ad2.private_ips,
                                                               module.instances-etcd-ad3.private_ips)))) }"
-  docker_device              = "${var.worker_docker_device}"
 }
 
 module "instances-k8sworker-ad3" {
@@ -334,7 +332,6 @@ module "instances-k8sworker-ad3" {
                                                               module.instances-etcd-ad1.private_ips,
                                                               module.instances-etcd-ad2.private_ips,
                                                               module.instances-etcd-ad3.private_ips)))) }"
-  docker_device              = "${var.worker_docker_device}"
 }
 
 ### Load Balancers

--- a/variables.tf
+++ b/variables.tf
@@ -309,7 +309,3 @@ variable nat_instance_ad3_enabled {
   description = "Whether to provision a NAT instance in AD 3 (only applicable when control_plane_subnet_access=private)"
   default     = "false"
 }
-
-variable "worker_docker_device" {
-  default = ""
-}


### PR DESCRIPTION
Signed-off-by: Garth Bushell <garth.bushell@oracle.com>

This change autodetects the NVMe disks and puts a spanned vole across all of them and then mounts at /var/lib/docker. 
This removes the generic docker_device field