### PR TITLE
update version of kubernetes from 1.7.4->1.7.10

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -265,7 +265,7 @@ variable "flannel_ver" {
 }
 
 variable "k8s_ver" {
-  default = "1.7.4"
+  default = "1.7.10"
 }
 
 variable "k8s_dashboard_ver" {


### PR DESCRIPTION
Signed-off-by: Garth Bushell <garth.bushell@oracle.com>

This is prep for cloud controller work and 1.7.6+ makes it easier. 

 