### PR TITLE
Make sure etcd is started

### DIFF
--- a/instances/etcd/cloud_init/bootstrap.template.sh
+++ b/instances/etcd/cloud_init/bootstrap.template.sh
@@ -60,6 +60,7 @@ if [ -n "$${iqn}" ]; then
 fi
 
 docker run -d \
+        --restart=always \
 	-p 2380:2380 -p 2379:2379 \
 	-v /etc/ssl/certs/ca-bundle.crt:/etc/ssl/certs/ca-bundle.crt \
 	-v /etcd:/$HOSTNAME.etcd \


### PR DESCRIPTION
Signed-off-by: Garth Bushell <garth.bushell@oracle.com>

Add --restart=always to etcd docker run command