### PR TITLE
add --retry 3 when GET https://discovery.etcd.io/new? in datasources.tf

### DIFF
--- a/datasources.tf
+++ b/datasources.tf
@@ -4,6 +4,6 @@ data "oci_identity_availability_domains" "ADs" {
 
 resource "template_file" "etcd_discovery_url" {
   provisioner "local-exec" {
-    command = "[ -d ${path.root}/generated ] || mkdir -p ${path.root}/generated && curl https://discovery.etcd.io/new?size=${var.etcdAd1Count + var.etcdAd2Count + var.etcdAd3Count} > ${path.root}/generated/discovery${self.id}"
+    command = "[ -d ${path.root}/generated ] || mkdir -p ${path.root}/generated && curl --retry 3 https://discovery.etcd.io/new?size=${var.etcdAd1Count + var.etcdAd2Count + var.etcdAd3Count} > ${path.root}/generated/discovery${self.id}"
   }
 }


### PR DESCRIPTION
add --retry 3 to curl command when trying to GET https://discovery.etcd.io/new?...
this change will help mitigate a rare issue that the pulled url sometimes returns "not ready ..."