### PR TITLE
Support in-cluster client authentication using service account

### DIFF
--- a/tls/main.tf
+++ b/tls/main.tf
@@ -19,6 +19,7 @@ resource "tls_self_signed_cert" "root-ca" {
   allowed_uses = [
     "key_encipherment",
     "cert_signing",
+    "digital_signature",
     "server_auth",
     "client_auth",
   ]


### PR DESCRIPTION
This resolves issue-134.  

With this change, clients running inside a Kubernetes cluster can authenticate to the API server using a service account token.

We are testing with an operator, written in Java, connecting with TLS and default algorithms and cipher suites.  This issue was discovered internally and by an alpha tester.