### PR TITLE
add variable for master_nodeport_ingress.  Defaults to 10.0.0.0/16 (p…

### DIFF
--- a/docs/input-variables.md
+++ b/docs/input-variables.md
@@ -118,6 +118,7 @@ master_ssh_ingress                  | 10.0.0.0/16 (VCN only)  | A CIDR notation 
 master_https_ingress                | 10.0.0.0/16 (VCN only)  | A CIDR notation IP range that is allowed to access the HTTPs port on the master(s). Must be a subset of the VCN CIDR.
 worker_ssh_ingress                  | 10.0.0.0/16 (VCN only)  | A CIDR notation IP range that is allowed to SSH to worker(s). Must be a subset of the VCN CIDR.
 worker_nodeport_ingress             | 10.0.0.0/16 (VCN only)  | A CIDR notation IP range that is allowed to access NodePorts (30000-32767) on the worker(s). Must be a subset of the VCN CIDR.
+master_nodeport_ingress             | 10.0.0.0/16 (VCN only)  | A CIDR notation IP range that is allowed to access NodePorts (30000-32767) on the masters(s). Must be a subset of the VCN CIDR. 
 
 
 #### _Private_ Network Access

--- a/k8s-oci.tf
+++ b/k8s-oci.tf
@@ -58,6 +58,7 @@ module "vcn" {
   dedicated_nat_subnets                   = "${var.dedicated_nat_subnets}"
   worker_ssh_ingress                      = "${var.worker_ssh_ingress}"
   worker_nodeport_ingress                 = "${var.worker_nodeport_ingress}"
+  master_nodeport_ingress                 = "${var.master_nodeport_ingress}"
   external_icmp_ingress                   = "${var.external_icmp_ingress}"
   internal_icmp_ingress                   = "${var.internal_icmp_ingress}"
 }

--- a/network/vcn/securitylists.tf
+++ b/network/vcn/securitylists.tf
@@ -138,6 +138,15 @@ resource "oci_core_security_list" "K8SMasterSubnet" {
       protocol = "6"
       source   = "${var.master_https_ingress}"
     },
+    {
+      tcp_options {
+        "min" = 30000
+        "max" = 32767
+      }
+
+      protocol = "6"
+      source   = "${var.master_nodeport_ingress}"
+    },
   ]
 
   provisioner "local-exec" {

--- a/network/vcn/variables.tf
+++ b/network/vcn/variables.tf
@@ -101,6 +101,10 @@ variable "worker_nodeport_ingress" {
   default = "10.0.0.0/16"
 }
 
+variable "master_nodeport_ingress" {
+  default = "10.0.0.0/16"
+}
+
 # For optional NAT instance (when control_plane_subnet_access = "private")
 
 variable "public_subnet_ssh_ingress" {

--- a/terraform.example.tfvars
+++ b/terraform.example.tfvars
@@ -36,6 +36,7 @@
 #worker_ssh_ingress = "0.0.0.0/0"
 #master_https_ingress = "0.0.0.0/0"
 #worker_nodeport_ingress = "0.0.0.0/0"
+#worker_nodeport_ingress = "10.0.0.0/16"
 
 #control_plane_subnet_access = "public"
 #k8s_master_lb_access = "public"

--- a/variables.tf
+++ b/variables.tf
@@ -181,6 +181,11 @@ variable "worker_nodeport_ingress" {
   default     = "10.0.0.0/16"
 }
 
+variable "master_nodeport_ingress" {
+  description = "A CIDR notation IP range that is allowed to access service ports to the instances on the master subnet"
+  default     = "10.0.0.0/16"
+}
+
 variable "public_subnet_ssh_ingress" {
   description = "A CIDR notation IP range that is allowed to SSH to instances on the public subnet"
   default     = "0.0.0.0/0"


### PR DESCRIPTION
…rivate), but allows the end user to expose the master nodeport range to ingress if desired.