### PR TITLE
Allow dns label config

### DIFF
--- a/docs/input-variables.md
+++ b/docs/input-variables.md
@@ -112,6 +112,7 @@ The following input variables are used to configure the inbound security rules o
 name                                | default                 | description
 ------------------------------------|-------------------------|------------
 network_cidrs                       | See map in variables.tf | A CIDR notation IP range of the VCN and its subnets.
+network_subnet_dns                  | See map in variables.tf | A DNS label for each of the subnet in the VCN (Max 15 characters)
 etcd_cluster_ingress                | 10.0.0.0/16 (VCN only)  | A CIDR notation IP range that is allowed to access the etcd cluster. Must be a subset of the VCN CIDR.
 etcd_ssh_ingress                    | 10.0.0.0/16 (VCN only)  | A CIDR notation IP range that is allowed to SSH to etcd nodes. Must be a subset of the VCN CIDR.
 master_ssh_ingress                  | 10.0.0.0/16 (VCN only)  | A CIDR notation IP range that is allowed to access the master(s). Must be a subset of the VCN CIDR.

--- a/k8s-oci.tf
+++ b/k8s-oci.tf
@@ -61,6 +61,7 @@ module "vcn" {
   master_nodeport_ingress                 = "${var.master_nodeport_ingress}"
   external_icmp_ingress                   = "${var.external_icmp_ingress}"
   internal_icmp_ingress                   = "${var.internal_icmp_ingress}"
+  network_subnet_dns                      = "${var.network_subnet_dns}"
 }
 
 module "oci-cloud-controller" {

--- a/network/vcn/subnets.tf
+++ b/network/vcn/subnets.tf
@@ -79,7 +79,7 @@ resource "oci_core_subnet" "etcdSubnetAD1" {
   cidr_block          = "${lookup(var.network_cidrs, "etcdSubnetAD1")}"
   compartment_id      = "${var.compartment_ocid}"
   display_name        = "${var.label_prefix}${var.control_plane_subnet_access}ETCDSubnetAD1"
-  dns_label           = "etcdsubnet1"
+  dns_label           = "${lookup(var.network_subnet_dns, "etcdSubnetAD1")}"
   vcn_id              = "${oci_core_virtual_network.CompleteVCN.id}"
 
   # Work around HIL issue #50 using join and use coalesce to pick the first route that is not empty (AD1 first pick)
@@ -98,7 +98,7 @@ resource "oci_core_subnet" "etcdSubnetAD2" {
   cidr_block          = "${lookup(var.network_cidrs, "etcdSubnetAD2")}"
   compartment_id      = "${var.compartment_ocid}"
   display_name        = "${var.label_prefix}${var.control_plane_subnet_access}ETCDSubnetAD2"
-  dns_label           = "etcdsubnet2"
+  dns_label           = "${lookup(var.network_subnet_dns, "etcdSubnetAD2")}"
   vcn_id              = "${oci_core_virtual_network.CompleteVCN.id}"
 
   # Work around HIL issue #50 using join and use coalesce to pick the first route that is not empty (AD2 first pick)
@@ -117,7 +117,7 @@ resource "oci_core_subnet" "etcdSubnetAD3" {
   cidr_block          = "${lookup(var.network_cidrs, "etcdSubnetAD3")}"
   compartment_id      = "${var.compartment_ocid}"
   display_name        = "${var.label_prefix}${var.control_plane_subnet_access}ETCDSubnetAD3"
-  dns_label           = "etcdsubnet3"
+  dns_label           = "${lookup(var.network_subnet_dns, "etcdSubnetAD3")}"
   vcn_id              = "${oci_core_virtual_network.CompleteVCN.id}"
 
   # Work around HIL issue #50 using join and use coalesce to pick the first route that is not empty (AD3 first pick)
@@ -136,7 +136,7 @@ resource "oci_core_subnet" "k8sMasterSubnetAD1" {
   cidr_block                 = "${lookup(var.network_cidrs, "masterSubnetAD1")}"
   compartment_id             = "${var.compartment_ocid}"
   display_name               = "${var.label_prefix}${var.control_plane_subnet_access}K8SMasterSubnetAD1"
-  dns_label                  = "k8smasterad1"
+  dns_label                  = "${lookup(var.network_subnet_dns, "masterSubnetAD1")}"
   vcn_id                     = "${oci_core_virtual_network.CompleteVCN.id}"
   route_table_id             = "${var.control_plane_subnet_access == "private" ? coalesce(join(" ", oci_core_route_table.NATInstanceAD1RouteTable.*.id), join(" ", oci_core_route_table.NATInstanceAD2RouteTable.*.id), join(" ", oci_core_route_table.NATInstanceAD3RouteTable.*.id), oci_core_route_table.PublicRouteTable.id) : oci_core_route_table.PublicRouteTable.id}"
   dhcp_options_id            = "${oci_core_virtual_network.CompleteVCN.default_dhcp_options_id}"
@@ -153,7 +153,7 @@ resource "oci_core_subnet" "k8sMasterSubnetAD2" {
   cidr_block                 = "${lookup(var.network_cidrs, "masterSubnetAD2")}"
   compartment_id             = "${var.compartment_ocid}"
   display_name               = "${var.label_prefix}${var.control_plane_subnet_access}K8SMasterSubnetAD2"
-  dns_label                  = "k8smasterad2"
+  dns_label                  = "${lookup(var.network_subnet_dns, "masterSubnetAD2")}"
   vcn_id                     = "${oci_core_virtual_network.CompleteVCN.id}"
   route_table_id             = "${var.control_plane_subnet_access == "private" ? coalesce(join(" ", oci_core_route_table.NATInstanceAD2RouteTable.*.id), join(" ", oci_core_route_table.NATInstanceAD1RouteTable.*.id), join(" ", oci_core_route_table.NATInstanceAD3RouteTable.*.id), oci_core_route_table.PublicRouteTable.id) : oci_core_route_table.PublicRouteTable.id}"
   dhcp_options_id            = "${oci_core_virtual_network.CompleteVCN.default_dhcp_options_id}"
@@ -170,7 +170,7 @@ resource "oci_core_subnet" "k8sMasterSubnetAD3" {
   cidr_block                 = "${lookup(var.network_cidrs, "masterSubnetAD3")}"
   compartment_id             = "${var.compartment_ocid}"
   display_name               = "${var.label_prefix}${var.control_plane_subnet_access}K8SMasterSubnetAD3"
-  dns_label                  = "k8smasterad3"
+  dns_label                  = "${lookup(var.network_subnet_dns, "masterSubnetAD3")}"
   vcn_id                     = "${oci_core_virtual_network.CompleteVCN.id}"
   route_table_id             = "${var.control_plane_subnet_access == "private" ? coalesce(join(" ", oci_core_route_table.NATInstanceAD3RouteTable.*.id), join(" ", oci_core_route_table.NATInstanceAD1RouteTable.*.id), join(" ", oci_core_route_table.NATInstanceAD2RouteTable.*.id), oci_core_route_table.PublicRouteTable.id) : oci_core_route_table.PublicRouteTable.id}"
   dhcp_options_id            = "${oci_core_virtual_network.CompleteVCN.default_dhcp_options_id}"
@@ -187,7 +187,7 @@ resource "oci_core_subnet" "k8sWorkerSubnetAD1" {
   cidr_block                 = "${lookup(var.network_cidrs, "workerSubnetAD1")}"
   compartment_id             = "${var.compartment_ocid}"
   display_name               = "${var.label_prefix}${var.control_plane_subnet_access}K8SWorkerSubnetAD1"
-  dns_label                  = "k8sworkerad1"
+  dns_label                  = "${lookup(var.network_subnet_dns, "workerSubnetAD1")}"
   vcn_id                     = "${oci_core_virtual_network.CompleteVCN.id}"
   route_table_id             = "${var.control_plane_subnet_access == "private" ? coalesce(join(" ", oci_core_route_table.NATInstanceAD1RouteTable.*.id), join(" ", oci_core_route_table.NATInstanceAD2RouteTable.*.id), join(" ", oci_core_route_table.NATInstanceAD3RouteTable.*.id), oci_core_route_table.PublicRouteTable.id) : oci_core_route_table.PublicRouteTable.id}"
   dhcp_options_id            = "${oci_core_virtual_network.CompleteVCN.default_dhcp_options_id}"
@@ -204,7 +204,7 @@ resource "oci_core_subnet" "k8sWorkerSubnetAD2" {
   cidr_block                 = "${lookup(var.network_cidrs, "workerSubnetAD2")}"
   compartment_id             = "${var.compartment_ocid}"
   display_name               = "${var.label_prefix}${var.control_plane_subnet_access}K8SWorkerSubnetAD2"
-  dns_label                  = "k8sworkerad2"
+  dns_label                  = "${lookup(var.network_subnet_dns, "workerSubnetAD2")}"
   vcn_id                     = "${oci_core_virtual_network.CompleteVCN.id}"
   route_table_id             = "${var.control_plane_subnet_access == "private" ? coalesce(join(" ", oci_core_route_table.NATInstanceAD2RouteTable.*.id), join(" ", oci_core_route_table.NATInstanceAD1RouteTable.*.id), join(" ", oci_core_route_table.NATInstanceAD3RouteTable.*.id), oci_core_route_table.PublicRouteTable.id) : oci_core_route_table.PublicRouteTable.id}"
   dhcp_options_id            = "${oci_core_virtual_network.CompleteVCN.default_dhcp_options_id}"
@@ -221,7 +221,7 @@ resource "oci_core_subnet" "k8sWorkerSubnetAD3" {
   cidr_block                 = "${lookup(var.network_cidrs, "workerSubnetAD3")}"
   compartment_id             = "${var.compartment_ocid}"
   display_name               = "${var.label_prefix}${var.control_plane_subnet_access}K8SWorkerSubnetAD3"
-  dns_label                  = "k8sworkerad3"
+  dns_label                  = "${lookup(var.network_subnet_dns, "workerSubnetAD3")}"
   vcn_id                     = "${oci_core_virtual_network.CompleteVCN.id}"
   route_table_id             = "${var.control_plane_subnet_access == "private" ? coalesce(join(" ", oci_core_route_table.NATInstanceAD3RouteTable.*.id), join(" ", oci_core_route_table.NATInstanceAD1RouteTable.*.id), join(" ", oci_core_route_table.NATInstanceAD2RouteTable.*.id), oci_core_route_table.PublicRouteTable.id) : oci_core_route_table.PublicRouteTable.id}"
   dhcp_options_id            = "${oci_core_virtual_network.CompleteVCN.default_dhcp_options_id}"
@@ -241,7 +241,7 @@ resource "oci_core_subnet" "k8sCCMLBSubnetAD1" {
   cidr_block                 = "${lookup(var.network_cidrs, "k8sCCMLBSubnetAD1")}"
   compartment_id             = "${var.compartment_ocid}"
   display_name               = "${var.label_prefix}PublicK8SCCMLBSubnetAD1"
-  dns_label                  = "k8sccmlbad1"
+  dns_label                  = "${lookup(var.network_subnet_dns, "k8sCCMLBSubnetAD1")}"
   vcn_id                     = "${oci_core_virtual_network.CompleteVCN.id}"
   route_table_id             = "${oci_core_route_table.PublicRouteTable.id}"
   dhcp_options_id            = "${oci_core_virtual_network.CompleteVCN.default_dhcp_options_id}"
@@ -258,7 +258,7 @@ resource "oci_core_subnet" "k8sCCMLBSubnetAD2" {
   cidr_block                 = "${lookup(var.network_cidrs, "k8sCCMLBSubnetAD2")}"
   compartment_id             = "${var.compartment_ocid}"
   display_name               = "${var.label_prefix}PublicK8SCCMLBSubnetAD2"
-  dns_label                  = "k8sccmlbad2"
+  dns_label                  = "${lookup(var.network_subnet_dns, "k8sCCMLBSubnetAD2")}"
   vcn_id                     = "${oci_core_virtual_network.CompleteVCN.id}"
   route_table_id             = "${oci_core_route_table.PublicRouteTable.id}"
   dhcp_options_id            = "${oci_core_virtual_network.CompleteVCN.default_dhcp_options_id}"
@@ -275,11 +275,11 @@ resource "oci_core_subnet" "k8sCCMLBSubnetAD3" {
   cidr_block                 = "${lookup(var.network_cidrs, "k8sCCMLBSubnetAD3")}"
   compartment_id             = "${var.compartment_ocid}"
   display_name               = "${var.label_prefix}PublicK8SCCMLBSubnetAD3"
-  dns_label                  = "k8sccmlbad3"
+  dns_label                  = "${lookup(var.network_subnet_dns, "k8sCCMLBSubnetAD3")}"
   vcn_id                     = "${oci_core_virtual_network.CompleteVCN.id}"
   route_table_id             = "${oci_core_route_table.PublicRouteTable.id}"
   dhcp_options_id            = "${oci_core_virtual_network.CompleteVCN.default_dhcp_options_id}"
-  security_list_ids          = ["${oci_core_security_list.K8SCCMLBSubnet.id}"]  
+  security_list_ids          = ["${oci_core_security_list.K8SCCMLBSubnet.id}"]
   prohibit_public_ip_on_vnic = "false"
 
   provisioner "local-exec" {

--- a/network/vcn/variables.tf
+++ b/network/vcn/variables.tf
@@ -24,6 +24,26 @@ variable "network_cidrs" {
   }
 }
 
+variable "network_subnet_dns" {
+  type = "map"
+
+  default = {
+    etcdSubnetAD1     = "etcdsubnet1"
+    etcdSubnetAD2     = "etcdsubnet2"
+    etcdSubnetAD3     = "etcdsubnet3"
+    masterSubnetAD1   = "k8smasterad1"
+    masterSubnetAD2   = "k8smasterad2"
+    masterSubnetAD3   = "k8smasterad3"
+    workerSubnetAD1   = "k8sworkerad1"
+    workerSubnetAD2   = "k8sworkerad2"
+    workerSubnetAD3   = "k8sworkerad3"
+    k8sCCMLBSubnetAD1 = "k8sccmlbad1"
+    k8sCCMLBSubnetAD2 = "k8sccmlbad2"
+    k8sCCMLBSubnetAD3 = "k8sccmlbad3"
+  }
+}
+
+
 variable "tenancy_ocid" {}
 
 variable "control_plane_subnet_access" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,26 @@ variable "network_cidrs" {
   }
 }
 
+variable "network_subnet_dns" {
+  type = "map"
+
+  default = {
+    etcdSubnetAD1     = "etcdsubnet1"
+    etcdSubnetAD2     = "etcdsubnet2"
+    etcdSubnetAD3     = "etcdsubnet3"
+    masterSubnetAD1   = "k8smasterad1"
+    masterSubnetAD2   = "k8smasterad2"
+    masterSubnetAD3   = "k8smasterad3"
+    workerSubnetAD1   = "k8sworkerad1"
+    workerSubnetAD2   = "k8sworkerad2"
+    workerSubnetAD3   = "k8sworkerad3"
+    k8sCCMLBSubnetAD1 = "k8sccmlbad1"
+    k8sCCMLBSubnetAD2 = "k8sccmlbad2"
+    k8sCCMLBSubnetAD3 = "k8sccmlbad3"
+  }
+}
+
+
 variable "domain_name" {
   default = "k8sbmcs.oraclevcn.com"
 }


### PR DESCRIPTION
This allows configuring the dns_labels for subnets when they are create. 
This is a mirror of the CIDR config and is needded to enable creation of a cluster in an existing VCN