### PR TITLE
temporarily disable advanced auditing. Resolves #177.

### DIFF
--- a/instances/k8smaster/manifests/kube-apiserver.yaml
+++ b/instances/k8smaster/manifests/kube-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
     - --audit-log-maxage=30
     - --audit-log-maxsize=100
     - --audit-log-path=/var/log/apiserver/audit.log
+    - --feature-gates=AdvancedAuditing=false
     - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,Initializers
     - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
     - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem


### PR DESCRIPTION
Temporarily disable advanced auditing until we can configure it properly. See #179.

Signed-off-by: Jesse Millan jesse.millan@oracle.com
