### PR TITLE
Updated image names to most recent

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -343,19 +343,19 @@ variable "k8s_dns_ver" {
 }
 
 variable "master_ol_image_name" {
-  default = "Oracle-Linux-7.4-2018.02.21-1"
+  default = "Oracle-Linux-7.5-2018.04.20-1"
 }
 
 variable "worker_ol_image_name" {
-  default = "Oracle-Linux-7.4-2018.02.21-1"
+  default = "Oracle-Linux-7.5-2018.04.20-1"
 }
 
 variable "etcd_ol_image_name" {
-  default = "Oracle-Linux-7.4-2018.02.21-1"
+  default = "Oracle-Linux-7.5-2018.04.20-1"
 }
 
 variable "nat_ol_image_name" {
-  default = "Oracle-Linux-7.4-2018.02.21-1"
+  default = "Oracle-Linux-7.5-2018.04.20-1"
 }
 
 variable "control_plane_subnet_access" {


### PR DESCRIPTION
OL image `Oracle-Linux-7.4-2018.02.21-1` contains a bug that locks the `opc` user account 90 days after launch. This pull request updates the instances names to the most recent OL7 release. 

Signed-off-by: Craig Carl <craig.carl@oracle.com>