### PR TITLE
Update to latest Oracle Enterprise Linux 7.5

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -349,19 +349,19 @@ variable "k8s_dns_ver" {
 }
 
 variable "master_ol_image_name" {
-  default = "Oracle-Linux-7.5-2018.07.20-0"
+  default = "Oracle-Linux-7.5-2018.10.16-0"
 }
 
 variable "worker_ol_image_name" {
-  default = "Oracle-Linux-7.5-2018.07.20-0"
+  default = "Oracle-Linux-7.5-2018.10.16-0"
 }
 
 variable "etcd_ol_image_name" {
-  default = "Oracle-Linux-7.5-2018.07.20-0"
+  default = "Oracle-Linux-7.5-2018.10.16-0"
 }
 
 variable "nat_ol_image_name" {
-  default = "Oracle-Linux-7.5-2018.07.20-0"
+  default = "Oracle-Linux-7.5-2018.10.16-0"
 }
 
 variable "control_plane_subnet_access" {


### PR DESCRIPTION
The image referenced by default in variables.tf is no longer available.  This brings it back up to date.