### PR TITLE
change name of LB backend sets to fit 32 char limit

### DIFF
--- a/network/loadbalancers/etcd/main.tf
+++ b/network/loadbalancers/etcd/main.tf
@@ -39,7 +39,7 @@ resource "oci_load_balancer_listener" "port-2379" {
   count                    = "${var.etcd_lb_enabled == "true" ? 1 : 0 }"
   load_balancer_id         = "${oci_load_balancer.lb-etcd.id}"
   name                     = "port-2379"
-  default_backend_set_name = "${oci_load_balancer_backendset.lb-etcd-backendset-2379.id}"
+  default_backend_set_name = "${oci_load_balancer_backendset.lb-etcd-backendset-2379.name}"
   port                     = 2379
   protocol                 = "TCP"
 }
@@ -48,7 +48,7 @@ resource "oci_load_balancer_listener" "port-2380" {
   count                    = "${var.etcd_lb_enabled == "true" ? 1 : 0 }"
   load_balancer_id         = "${oci_load_balancer.lb-etcd.id}"
   name                     = "port-2380"
-  default_backend_set_name = "${oci_load_balancer_backendset.lb-etcd-backendset-2380.id}"
+  default_backend_set_name = "${oci_load_balancer_backendset.lb-etcd-backendset-2380.name}"
   port                     = 2380
   protocol                 = "TCP"
 }

--- a/network/loadbalancers/k8smaster/main.tf
+++ b/network/loadbalancers/k8smaster/main.tf
@@ -26,7 +26,7 @@ resource "oci_load_balancer_listener" "port-https" {
   count                    = "${var.master_oci_lb_enabled == "true" ? 1 : 0 }"
   load_balancer_id         = "${oci_load_balancer.lb-k8smaster.id}"
   name                     = "port-https"
-  default_backend_set_name = "${oci_load_balancer_backendset.lb-k8smaster-https.id}"
+  default_backend_set_name = "${oci_load_balancer_backendset.lb-k8smaster-https.name}"
   port                     = 443
   protocol                 = "TCP"
 }


### PR DESCRIPTION
proposal to fix https://github.com/oracle/terraform-kubernetes-installer/issues/213
OCI seems to require load balancer backend set names to be 32 characters or fewer, so naming the set with the ID is throwing 400 error messages during terraform apply.