### PR TITLE
Fix bug in cloud-init script to get FQDN and update to a more recent image

### DIFF
--- a/docs/input-variables.md
+++ b/docs/input-variables.md
@@ -66,10 +66,10 @@ flannel_ver                         | v0.9.1                         | Version o
 k8s_ver                             | 1.8.5                          | Version of K8s to install (master and workers)
 k8s_dns_ver                         | 1.14.2                         | Version of Kube DNS to install
 k8s_dashboard_ver                   | 1.6.3                          | Version of Kubernetes dashboard to install
-master_ol_image_name                | Oracle-Linux-7.4-2018.01.20-0  | Image name of an Oracle-Linux-7.X image to use for masters
-worker_ol_image_name                | Oracle-Linux-7.4-2018.01.20-0  | Image name of an Oracle-Linux-7.X image to use for workers
-etcd_ol_image_name                  | Oracle-Linux-7.4-2018.01.20-0  | Image name of an Oracle-Linux-7.X image to use for etcd nodes
-nat_ol_image_name                   | Oracle-Linux-7.4-2018.01.20-0  | Image name of an Oracle-Linux-7.X image to use for NAT instances (if applicable)
+master_ol_image_name                | Oracle-Linux-7.5-2018.10.16-0  | Image name of an Oracle-Linux-7.X image to use for masters
+worker_ol_image_name                | Oracle-Linux-7.5-2018.10.16-0  | Image name of an Oracle-Linux-7.X image to use for workers
+etcd_ol_image_name                  | Oracle-Linux-7.5-2018.10.16-0  | Image name of an Oracle-Linux-7.X image to use for etcd nodes
+nat_ol_image_name                   | Oracle-Linux-7.5-2018.10.16-0  | Image name of an Oracle-Linux-7.X image to use for NAT instances (if applicable)
 
 #### OCI Plugins
 name                                     | default   | description

--- a/instances/etcd/variables.tf
+++ b/instances/etcd/variables.tf
@@ -24,7 +24,7 @@ variable "docker_ver" {
 }
 
 variable "oracle_linux_image_name" {
-  default = "Oracle-Linux-7.4-2018.01.20-0"
+  default = "Oracle-Linux-7.5-2018.10.16-0"
 }
 
 variable "etcd_ver" {

--- a/instances/k8smaster/scripts/setup.template.sh
+++ b/instances/k8smaster/scripts/setup.template.sh
@@ -2,7 +2,7 @@
 
 EXTERNAL_IP=$(curl -s -m 10 http://whatismyip.akamai.com/)
 NAMESPACE=$(echo -n "${domain_name}" | sed "s/\.oraclevcn\.com//g")
-FQDN_HOSTNAME=$(getent hosts $(ip route get 1 | awk '{print $NF;exit}') | awk '{print $2}')
+FQDN_HOSTNAME=$(hostname -f)
 
 # Pull instance metadata
 curl -sL --retry 3 http://169.254.169.254/opc/v1/instance/ | tee /tmp/instance_meta.json

--- a/instances/k8smaster/variables.tf
+++ b/instances/k8smaster/variables.tf
@@ -40,7 +40,7 @@ variable "docker_ver" {
 }
 
 variable "oracle_linux_image_name" {
-  default = "Oracle-Linux-7.4-2018.01.20-0"
+  default = "Oracle-Linux-7.5-2018.10.16-0"
 }
 
 variable "etcd_ver" {

--- a/instances/k8sworker/scripts/setup.template.sh
+++ b/instances/k8sworker/scripts/setup.template.sh
@@ -2,7 +2,7 @@
 
 EXTERNAL_IP=$(curl -s -m 10 http://whatismyip.akamai.com/)
 NAMESPACE=$(echo -n "${domain_name}" | sed "s/\.oraclevcn\.com//g")
-FQDN_HOSTNAME=$(getent hosts $(ip route get 1 | awk '{print $NF;exit}') | awk '{print $2}')
+FQDN_HOSTNAME=$(hostname -f)
 
 # Pull instance metadata
 curl -sL --retry 3 http://169.254.169.254/opc/v1/instance/ | tee /tmp/instance_meta.json

--- a/instances/k8sworker/variables.tf
+++ b/instances/k8sworker/variables.tf
@@ -30,7 +30,7 @@ variable "docker_ver" {
 }
 
 variable "oracle_linux_image_name" {
-  default = "Oracle-Linux-7.4-2018.01.20-0"
+  default = "Oracle-Linux-7.5-2018.10.16-0"
 }
 
 # Kubernetes

--- a/network/vcn/variables.tf
+++ b/network/vcn/variables.tf
@@ -150,7 +150,7 @@ variable "internal_icmp_ingress" {
 variable "nat_instance_ssh_public_key_openssh" {}
 
 variable "nat_instance_oracle_linux_image_name" {
-  default = "Oracle-Linux-7.4-2018.01.20-0"
+  default = "Oracle-Linux-7.5-2018.10.16-0"
 }
 
 variable "nat_instance_shape" {

--- a/variables.tf
+++ b/variables.tf
@@ -349,19 +349,19 @@ variable "k8s_dns_ver" {
 }
 
 variable "master_ol_image_name" {
-  default = "Oracle-Linux-7.5-2018.08.14-0"
+  default = "Oracle-Linux-7.5-2018.10.16-0"
 }
 
 variable "worker_ol_image_name" {
-  default = "Oracle-Linux-7.5-2018.08.14-0"
+  default = "Oracle-Linux-7.5-2018.10.16-0"
 }
 
 variable "etcd_ol_image_name" {
-  default = "Oracle-Linux-7.5-2018.08.14-0"
+  default = "Oracle-Linux-7.5-2018.10.16-0"
 }
 
 variable "nat_ol_image_name" {
-  default = "Oracle-Linux-7.5-2018.08.14-0"
+  default = "Oracle-Linux-7.5-2018.10.16-0"
 }
 
 variable "control_plane_subnet_access" {


### PR DESCRIPTION
This pull request fixes bug in cloud-init script to get fully qualified host name, which is used as a unique node name. This issue was previously blocking us from using a more recent image.

Resolves #216.

 Signed-off-by: Jesse Millan jesse.millan@oracle.com